### PR TITLE
Automate input normalisation

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -15,6 +15,7 @@ def parse_args(args=None):
     parser = argparse.ArgumentParser(description=Description, epilog=Epilog)
     parser.add_argument("FILE_IN", help="Input samplesheet file.")
     parser.add_argument("FILE_OUT", help="Output file.")
+    parser.add_argument('--version', action='version', version='%(prog)s 1.0')
     return parser.parse_args(args)
 
 

--- a/bin/tol_input.sh
+++ b/bin/tol_input.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 
-if [ $# -eq 0 ]; then echo -e "Please provide a ToL ID. \nUsage: ./automate_io <tol_id> <tol_project>. \n<tol_id> must match the expected genome. \n<tol_project> defaults to 'darwin'."; exit 1; fi
+PROJECT_BASEDIR=/lustre/scratch124/tol/projects
 
-id=$1
-project=$2
-data=/lustre/scratch124/tol/projects/$project/data
+if [ $# -ne 2 ]; then echo -e "Script to create a samplesheet for a species.\nUsage: $0 <tol_id> <tol_project>.\nVersion: 1.0"; exit 1; fi
+
+id="$1"
+project="$2"
+data="$PROJECT_BASEDIR/$project/data"
+
+if [[ ! -d "$data" ]]
+then
+    echo "Project "$project" cannot be found under $PROJECT_BASEDIR"
+    exit 1
+fi
 
 if compgen -G $data/*/*/assembly/release/${id}.[0-9]/insdc/GCA*fasta.gz > /dev/null
     then genome=$(ls $data/*/*/assembly/release/${id}.[0-9]/insdc/GCA*fasta.gz | tail -1)
 elif compgen -G $data/*/*/assembly/release/${id}.[0-9]_{p,m}aternal_haplotype/insdc/GCA*fasta.gz > /dev/null
     then genome=$(ls $data/*/*/assembly/release/${id}.[0-9]_*aternal_haplotype/insdc/GCA*fasta.gz | tail -1)
-else echo "Genome for $id not found"; exit 1; fi
+else echo "Genome for $id not found in $data"; exit 1; fi
 
 taxon=$(echo $genome | cut -f8 -d'/')
 organism=$(echo $genome | cut -f9 -d'/')
@@ -31,5 +39,5 @@ else echo "No cram files."; exit 1; fi
 
 if compgen -G $analysis/assembly/indices/${gca}.unmasked.fasta > /dev/null
     then cp $analysis/assembly/indices/${gca}.unmasked.fasta ./
-else "Unmasked fasta does not exist."; exit 1; fi
+else echo "Unmasked fasta does not exist."; exit 1; fi
 

--- a/modules/local/input_tol.nf
+++ b/modules/local/input_tol.nf
@@ -1,5 +1,5 @@
 process INPUT_TOL {
-    label 'process_nompi'
+    label 'process_single'
 
     conda (params.enable_conda ? "conda-forge::gawk=5.1.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/input_tol.nf
+++ b/modules/local/input_tol.nf
@@ -13,6 +13,7 @@ process INPUT_TOL {
     output:
     path "*.unmasked.fasta", emit: fasta
     path "samplesheet.csv",  emit: csv
+    path "versions.yml",     emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/input_tol.nf
+++ b/modules/local/input_tol.nf
@@ -19,8 +19,9 @@ process INPUT_TOL {
     task.ext.when == null || task.ext.when
 
     script:
+    def args = task.ext.args ?: ''
     """
-    tol_input.sh "$tolid" "$project"
+    tol_input.sh "$tolid" "$project" $args
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/input_tol.nf
+++ b/modules/local/input_tol.nf
@@ -18,13 +18,12 @@ process INPUT_TOL {
     task.ext.when == null || task.ext.when
 
     script:
-    def proj = project ? "${project}" : ""
     """
-    tol_input.sh $tolid ${proj}
+    tol_input.sh "$tolid" "$project"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        GNU Awk: \$(echo \$(awk --version 2>&1) | grep -i awk | sed 's/GNU Awk //; s/,.*//')
+        tol_input.sh: \$(tol_input.sh | tail -n 1 | cut -d' ' -f2)
     END_VERSIONS
     """
 }

--- a/modules/local/samplesheet_check.nf
+++ b/modules/local/samplesheet_check.nf
@@ -21,7 +21,7 @@ process SAMPLESHEET_CHECK {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        python: \$(python --version | sed 's/Python //g')
+        check_samplesheet.py: \$(check_samplesheet.py --version | cut -d' ' -f2)
     END_VERSIONS
     """
 }

--- a/modules/local/samplesheet_check.nf
+++ b/modules/local/samplesheet_check.nf
@@ -1,5 +1,6 @@
 process SAMPLESHEET_CHECK {
     tag "$samplesheet"
+    label 'process_single'
 
     conda (params.enable_conda ? "conda-forge::python=3.9.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/samplesheet_check.nf
+++ b/modules/local/samplesheet_check.nf
@@ -14,7 +14,7 @@ process SAMPLESHEET_CHECK {
     path '*.csv'       , emit: csv
     path "versions.yml", emit: versions
 
-    script: // This script is bundled with the pipeline, in nf-core/readmapping/bin/
+    script: // This script is bundled with the pipeline, in nf-core/variantcalling/bin/
     """
     check_samplesheet.py \\
         $samplesheet \\


### PR DESCRIPTION
Hi @DLBPointon 

We're coming up with a guideline for versioning scripts, starting with the automate_io subworkflow. This PR updates a couple of scripts and modules accordingly

For Python scripts, support for --version can be added with a one-liner like this. Then, the .nf shoud call that rather printing the Python version.
For shell scripts, you can add a one-liner in your shell script to check that the number of arguments is correct, and print a short usage message + version otherwise.

Can you then consider doing the same for your own scripts ? They're all essentially very easy to add, and then the scripts are versioned and it's clear which version of the script was used.

Thanks !

PS: this PR has extra changes in tol_input.sh so that it is (almost) exactly the same as in the other pipelines