### PR TITLE
Missing align flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
 
       - name: Run pipeline with unaligned test data
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test_align,docker --outdir ./results --align
+          nextflow run ${GITHUB_WORKSPACE} -profile test_align,docker --outdir ./results

--- a/.github/workflows/sanger_test.yml
+++ b/.github/workflows/sanger_test.yml
@@ -18,8 +18,7 @@ jobs:
           workdir: ${{ secrets.TOWER_WORKDIR_PARENT }}/work/${{ github.repository }}/work-${{ github.sha }}
           parameters: |
             {
-              "outdir": "${{ secrets.TOWER_WORKDIR_PARENT }}/results/${{ github.repository }}/results-${{ github.sha }}",
-              "align":  true
+              "outdir": "${{ secrets.TOWER_WORKDIR_PARENT }}/results/${{ github.repository }}/results-${{ github.sha }}"
             }
           profiles: test_align,sanger,singularity,cleanup
 

--- a/.github/workflows/sanger_test_full.yml
+++ b/.github/workflows/sanger_test_full.yml
@@ -31,8 +31,7 @@ jobs:
           workdir: ${{ secrets.TOWER_WORKDIR_PARENT }}/work/${{ github.repository }}/work-${{ env.REVISION }}
           parameters: |
             {
-              "outdir": "${{ secrets.TOWER_WORKDIR_PARENT }}/results/${{ github.repository }}/results-${{ env.REVISION }}",
-              "align":  true,
+              "outdir": "${{ secrets.TOWER_WORKDIR_PARENT }}/results/${{ github.repository }}/results-${{ env.REVISION }}"
             }
           profiles: test_full_align,sanger,singularity,cleanup
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Steps involved:
    nextflow run sanger-tol/variantcalling -profile test,YOURPROFILE --outdir <OUTDIR>
 
    # for unaligned reads
-   nextflow run sanger-tol/variantcalling -profile test_align,YOURPROFILE --align --outdir <OUTDIR>
+   nextflow run sanger-tol/variantcalling -profile test_align,YOURPROFILE --outdir <OUTDIR>
 
    ```
 

--- a/conf/test_align.config
+++ b/conf/test_align.config
@@ -21,6 +21,7 @@ params {
 
     // Input data
     input  = "${projectDir}/assets/samplesheet_test_align.csv"
+    align  = true
 
     // Fasta references
     fasta = "https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/assembly/GCA_947369205.1_OX376310.1_CANBKR010000003.1.fasta.gz"

--- a/conf/test_full_align.config
+++ b/conf/test_full_align.config
@@ -18,6 +18,7 @@ params {
 
     // Input data for full size test
     input = "${projectDir}/assets/samplesheet_test_full_align.csv"
+    align = true
 
     // Fasta references
     fasta = "/lustre/scratch124/tol/projects/darwin/data/insects/Polyommatus_icarus/assembly/release/ilPolIcar1.1/insdc/GCA_937595015.1.fasta.gz"


### PR DESCRIPTION
When doing some tests, I found out that the `test_align` profile doesn't set `align` to `true`. Was I doing anything wrong ?
Here's a PR to fix that, onto the `dev` branch because I didn't feel it warrants a new release yet (but if we have to make a 1.1.4 release then I would ask to cherry-pick the commit).

<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
