### PR TITLE
Add visual report

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -89,11 +89,11 @@ process {
 
     withName: '.*:DEEPVARIANT_CALLER:DEEPVARIANT' {
         ext.args = '--model_type=PACBIO'
-	publishDir = [
+        publishDir = [
             path: { "${params.outdir}/variant_calling/deepvariant_reports" },
             mode: params.publish_dir_mode,
-	    pattern: '*.visual_report.html',
-	]
+            pattern: '*.visual_report.html',
+        ]
     }
 
     withName: '.*:DEEPVARIANT_CALLER:BCFTOOLS_CONCAT_VCF' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -89,6 +89,11 @@ process {
 
     withName: '.*:DEEPVARIANT_CALLER:DEEPVARIANT' {
         ext.args = '--model_type=PACBIO'
+	publishDir = [
+            path: { "${params.outdir}/variant_calling" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+	]
     }
 
     withName: '.*:DEEPVARIANT_CALLER:BCFTOOLS_CONCAT_VCF' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -90,9 +90,9 @@ process {
     withName: '.*:DEEPVARIANT_CALLER:DEEPVARIANT' {
         ext.args = '--model_type=PACBIO'
 	publishDir = [
-            path: { "${params.outdir}/variant_calling" },
+            path: { "${params.outdir}/variant_calling/deepvariant_reports" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+	    pattern: '*.visual_report.html',
 	]
     }
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -43,17 +43,6 @@ The statistics for the aligned CRAM files will be calculated using `samtools`.
 
 </details>
 
-### Deepvariant Report
-
-The running HTML report of `deepvariant`.
-
-<details markdown="1">
-<summary>Output files</summary>
-
-- Visual Repoty by DeepVariant: `<sample_name>_<sample_name>.visual_report.html`.
-
-</details>
-
 ### VCFtools Processing
 
 <details markdown="1">
@@ -74,6 +63,8 @@ The aligned PacBio read data is used to call variants with DeepVariant. This is 
 - `variant_calling`
   - Compressed VCF files: `<fasta_name>.pacbio.<sample_name>_deepvariant.vcf.gz`.
   - Compressed GVCF files: `<fasta_name>.pacbio.<sample_name>_deepvariant.g.vcf.gz`.
+  - `deepvariant_reports`
+    - HTML files: `<sample_name>_<fasta_name>.visual_report.html`.
 
 </details>
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -43,6 +43,17 @@ The statistics for the aligned CRAM files will be calculated using `samtools`.
 
 </details>
 
+### Deepvariant Report
+
+The running report of `deepvariant`.
+
+<details markdown="1">
+<summary>Output files</summary>
+
+- Visual Repoty by DeepVariant: `<sample_name>_<sample_name>.visual_report.html`.
+
+</details>
+
 ### VCFtools Processing
 
 <details markdown="1">

--- a/docs/output.md
+++ b/docs/output.md
@@ -45,7 +45,7 @@ The statistics for the aligned CRAM files will be calculated using `samtools`.
 
 ### Deepvariant Report
 
-The running report of `deepvariant`.
+The running HTML report of `deepvariant`.
 
 <details markdown="1">
 <summary>Output files</summary>

--- a/modules/nf-core/deepvariant/rundeepvariant/deepvariant-rundeepvariant.diff
+++ b/modules/nf-core/deepvariant/rundeepvariant/deepvariant-rundeepvariant.diff
@@ -1,24 +1,60 @@
-Changes in module 'nf-core/deepvariant/rundeepvariant'
+Changes in component 'nf-core/deepvariant/rundeepvariant'
+Changes in 'deepvariant/rundeepvariant/meta.yml':
+--- modules/nf-core/deepvariant/rundeepvariant/meta.yml
++++ modules/nf-core/deepvariant/rundeepvariant/meta.yml
+@@ -109,6 +109,16 @@
+           type: file
+           description: Tabix index file of compressed GVCF
+           pattern: "*.g.vcf.gz.tbi"
++  - visual_report:
++      - meta:
++          type: map
++          description: |
++            Groovy Map containing sample information
++            e.g. [ id:'test', single_end:false ]
++      - ${prefix}.visual_report.html:
++          type: file
++          description: HTML file of visual report
++          pattern: "*.visual_report.html"
+   - versions:
+       - versions.yml:
+           type: file
+
+'modules/nf-core/deepvariant/rundeepvariant/.nextflow.log' was created
+Changes in 'deepvariant/rundeepvariant/main.nf':
 --- modules/nf-core/deepvariant/rundeepvariant/main.nf
 +++ modules/nf-core/deepvariant/rundeepvariant/main.nf
-@@ -14,12 +14,12 @@
-     tuple val(meta4), path(gzi)
+@@ -15,11 +15,12 @@
      tuple val(meta5), path(par_bed)
  
--    output:
+     output:
 -    tuple val(meta), path("${prefix}.vcf.gz")      ,  emit: vcf
 -    tuple val(meta), path("${prefix}.vcf.gz.tbi")  ,  emit: vcf_tbi
 -    tuple val(meta), path("${prefix}.g.vcf.gz")    ,  emit: gvcf
 -    tuple val(meta), path("${prefix}.g.vcf.gz.tbi"),  emit: gvcf_tbi
 -    path "versions.yml"                            ,  emit: versions
-+output:
 +    tuple val(meta), path("${prefix}.vcf.gz")             , emit: vcf
 +    tuple val(meta), path("${prefix}.vcf.gz.{tbi,csi}")   , emit: vcf_index
 +    tuple val(meta), path("${prefix}.g.vcf.gz")           , emit: gvcf
 +    tuple val(meta), path("${prefix}.g.vcf.gz.{tbi,csi}") , emit: gvcf_index
++    tuple val(meta), path("${prefix}.visual_report.html") , emit: visual_report
 +    path "versions.yml"                                   , emit: versions
  
      when:
      task.ext.when == null || task.ext.when
+@@ -69,6 +70,7 @@
+     touch ${prefix}.vcf.gz.tbi
+     touch ${prefix}.g.vcf.gz
+     touch ${prefix}.g.vcf.gz.tbi
++    touch ${prefix}.visual_report.html
+ 
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
 
+'modules/nf-core/deepvariant/rundeepvariant/tests/main.nf.test' is unchanged
+'modules/nf-core/deepvariant/rundeepvariant/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/deepvariant/rundeepvariant/tests/nextflow-intervals.config' is unchanged
+'modules/nf-core/deepvariant/rundeepvariant/tests/nextflow-non-autosomal-calling.config' is unchanged
+'modules/nf-core/deepvariant/rundeepvariant/tests/nextflow.config' is unchanged
+'modules/nf-core/deepvariant/rundeepvariant/tests/tags.yml' is unchanged
 ************************************************************

--- a/modules/nf-core/deepvariant/rundeepvariant/main.nf
+++ b/modules/nf-core/deepvariant/rundeepvariant/main.nf
@@ -14,11 +14,12 @@ process DEEPVARIANT_RUNDEEPVARIANT {
     tuple val(meta4), path(gzi)
     tuple val(meta5), path(par_bed)
 
-output:
+    output:
     tuple val(meta), path("${prefix}.vcf.gz")             , emit: vcf
     tuple val(meta), path("${prefix}.vcf.gz.{tbi,csi}")   , emit: vcf_index
     tuple val(meta), path("${prefix}.g.vcf.gz")           , emit: gvcf
     tuple val(meta), path("${prefix}.g.vcf.gz.{tbi,csi}") , emit: gvcf_index
+    tuple val(meta), path("${prefix}.visual_report.html") , emit: visual_report
     path "versions.yml"                                   , emit: versions
 
     when:

--- a/modules/nf-core/deepvariant/rundeepvariant/main.nf
+++ b/modules/nf-core/deepvariant/rundeepvariant/main.nf
@@ -19,7 +19,6 @@ output:
     tuple val(meta), path("${prefix}.vcf.gz.{tbi,csi}")   , emit: vcf_index
     tuple val(meta), path("${prefix}.g.vcf.gz")           , emit: gvcf
     tuple val(meta), path("${prefix}.g.vcf.gz.{tbi,csi}") , emit: gvcf_index
-    tuple val(meta), path("${prefix}.visual_report.html"), emit: visual_report
     path "versions.yml"                                   , emit: versions
 
     when:

--- a/modules/nf-core/deepvariant/rundeepvariant/main.nf
+++ b/modules/nf-core/deepvariant/rundeepvariant/main.nf
@@ -19,6 +19,7 @@ output:
     tuple val(meta), path("${prefix}.vcf.gz.{tbi,csi}")   , emit: vcf_index
     tuple val(meta), path("${prefix}.g.vcf.gz")           , emit: gvcf
     tuple val(meta), path("${prefix}.g.vcf.gz.{tbi,csi}") , emit: gvcf_index
+    tuple val(meta), path("${prefix}.visual_report.html"), emit: visual_report
     path "versions.yml"                                   , emit: versions
 
     when:
@@ -69,6 +70,7 @@ output:
     touch ${prefix}.vcf.gz.tbi
     touch ${prefix}.g.vcf.gz
     touch ${prefix}.g.vcf.gz.tbi
+    touch ${prefix}.visual_report.html
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/deepvariant/rundeepvariant/meta.yml
+++ b/modules/nf-core/deepvariant/rundeepvariant/meta.yml
@@ -109,6 +109,16 @@ output:
           type: file
           description: Tabix index file of compressed GVCF
           pattern: "*.g.vcf.gz.tbi"
+  - visual_report:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - ${prefix}.visual_report.html:
+          type: file
+          description: HTML file of visual report
+          pattern: "*.visual_report.html"
   - versions:
       - versions.yml:
           type: file

--- a/subworkflows/local/deepvariant_caller.nf
+++ b/subworkflows/local/deepvariant_caller.nf
@@ -89,6 +89,5 @@ workflow DEEPVARIANT_CALLER {
     emit:
     vcf      = BCFTOOLS_CONCAT_VCF.out.vcf         // channel: [ val(meta), path(vcf) ]
     gvcf     = BCFTOOLS_CONCAT_GVCF.out.vcf        // channel: [ val(meta), path(gvcf) ]
-    html     = DEEPVARIANT.out.visual_report       // channel: [ val(meta), path(visual_report) ]
     versions = ch_versions                         // channel: [ versions.yml ]
 }

--- a/subworkflows/local/deepvariant_caller.nf
+++ b/subworkflows/local/deepvariant_caller.nf
@@ -89,5 +89,6 @@ workflow DEEPVARIANT_CALLER {
     emit:
     vcf      = BCFTOOLS_CONCAT_VCF.out.vcf         // channel: [ val(meta), path(vcf) ]
     gvcf     = BCFTOOLS_CONCAT_GVCF.out.vcf        // channel: [ val(meta), path(gvcf) ]
+    html     = DEEPVARIANT.out.visual_report       // channel: [ val(meta), path(visual_report) ]
     versions = ch_versions                         // channel: [ versions.yml ]
 }


### PR DESCRIPTION
<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Output Documentation in `docs/output.md` is updated.


This PR is to address issue #89 (publish visual_report files). To test these changes, I ran the test profile for aligned reads and verified that the report was emitted on the outdir/variantcalling folder.
The changes I made were:
- adding an emission in the deepvariant module/subworkflow and its stub;
- adding the publishdir for deepvariant process on modules.config
- adding the report description on meta.yml

nf-core linting failed, but all messages were related to outdated schemas of the pipeline.

And answering the question on the issue, MultiQC does not support deepvariant (https://docs.seqera.io/multiqc/modules/).