### PR TITLE
Update deepvariant to 1.9.0

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -33,7 +33,7 @@
                     },
                     "deepvariant/rundeepvariant": {
                         "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "git_sha": "123fdbae2bf2c827b2e11ae09c4d481f446b8ffb",
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/deepvariant/rundeepvariant/deepvariant-rundeepvariant.diff"
                     },

--- a/modules/nf-core/deepvariant/rundeepvariant/meta.yml
+++ b/modules/nf-core/deepvariant/rundeepvariant/meta.yml
@@ -79,16 +79,16 @@ output:
           type: file
           description: Compressed VCF file
           pattern: "*.vcf.gz"
-  - vcf_tbi:
+  - vcf_index:
       - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - ${prefix}.vcf.gz.tbi:
+      - ${prefix}.vcf.gz.{tbi,csi}:
           type: file
           description: Tabix index file of compressed VCF
-          pattern: "*.vcf.gz.tbi"
+          pattern: "*.vcf.gz.{tbi,csi}"
   - gvcf:
       - meta:
           type: map
@@ -99,16 +99,16 @@ output:
           type: file
           description: Compressed GVCF file
           pattern: "*.g.vcf.gz"
-  - gvcf_tbi:
+  - gvcf_index:
       - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
-      - ${prefix}.g.vcf.gz.tbi:
+      - ${prefix}.g.vcf.gz.{tbi,csi}:
           type: file
           description: Tabix index file of compressed GVCF
-          pattern: "*.g.vcf.gz.tbi"
+          pattern: "*.g.vcf.gz.{tbi,csi}"
   - visual_report:
       - meta:
           type: map

--- a/modules/nf-core/deepvariant/rundeepvariant/tests/main.nf.test.snap
+++ b/modules/nf-core/deepvariant/rundeepvariant/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz:md5,8b8ab4a675f01e437aa72e1438a717d0"
+                        "test_out.vcf.gz:md5,707212230030c8c3efbe5c2e0428da03"
                     ]
                 ],
                 "1": [
@@ -17,7 +17,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz.tbi:md5,0000833138104e87b05eaa906821eb21"
+                        "test_out.vcf.gz.tbi:md5,248648ca03f5fda904ebbef8821e0e37"
                     ]
                 ],
                 "2": [
@@ -26,7 +26,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz:md5,0a629e1745926cfcedf4b169046a921a"
+                        "test_out.g.vcf.gz:md5,89b2e47883a65bb9cae8f173e782bb17"
                     ]
                 ],
                 "3": [
@@ -35,11 +35,11 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz.tbi:md5,49503913c28ec70a6f4aa52f6b357b4d"
+                        "test_out.g.vcf.gz.tbi:md5,1680c67fe988bc1d8220fbb4127c2c18"
                     ]
                 ],
                 "4": [
-                    "versions.yml:md5,a251d8d9f5e8b737d8298eead96c0890"
+                    "versions.yml:md5,3609b8b1430f8fa9038d70e359be0056"
                 ],
                 "gvcf": [
                     [
@@ -47,7 +47,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz:md5,0a629e1745926cfcedf4b169046a921a"
+                        "test_out.g.vcf.gz:md5,89b2e47883a65bb9cae8f173e782bb17"
                     ]
                 ],
                 "gvcf_tbi": [
@@ -56,7 +56,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz.tbi:md5,49503913c28ec70a6f4aa52f6b357b4d"
+                        "test_out.g.vcf.gz.tbi:md5,1680c67fe988bc1d8220fbb4127c2c18"
                     ]
                 ],
                 "vcf": [
@@ -65,7 +65,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz:md5,8b8ab4a675f01e437aa72e1438a717d0"
+                        "test_out.vcf.gz:md5,707212230030c8c3efbe5c2e0428da03"
                     ]
                 ],
                 "vcf_tbi": [
@@ -74,19 +74,19 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz.tbi:md5,0000833138104e87b05eaa906821eb21"
+                        "test_out.vcf.gz.tbi:md5,248648ca03f5fda904ebbef8821e0e37"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a251d8d9f5e8b737d8298eead96c0890"
+                    "versions.yml:md5,3609b8b1430f8fa9038d70e359be0056"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2024-08-29T11:36:27.325363"
+        "timestamp": "2025-05-14T08:00:40.832473535"
     },
     "homo_sapiens - [bam, bai] - fasta - fai": {
         "content": [
@@ -97,7 +97,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz:md5,8b8ab4a675f01e437aa72e1438a717d0"
+                        "test_out.vcf.gz:md5,707212230030c8c3efbe5c2e0428da03"
                     ]
                 ],
                 "1": [
@@ -106,7 +106,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz.tbi:md5,0000833138104e87b05eaa906821eb21"
+                        "test_out.vcf.gz.tbi:md5,248648ca03f5fda904ebbef8821e0e37"
                     ]
                 ],
                 "2": [
@@ -115,7 +115,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz:md5,0a629e1745926cfcedf4b169046a921a"
+                        "test_out.g.vcf.gz:md5,89b2e47883a65bb9cae8f173e782bb17"
                     ]
                 ],
                 "3": [
@@ -124,11 +124,11 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz.tbi:md5,49503913c28ec70a6f4aa52f6b357b4d"
+                        "test_out.g.vcf.gz.tbi:md5,1680c67fe988bc1d8220fbb4127c2c18"
                     ]
                 ],
                 "4": [
-                    "versions.yml:md5,a251d8d9f5e8b737d8298eead96c0890"
+                    "versions.yml:md5,3609b8b1430f8fa9038d70e359be0056"
                 ],
                 "gvcf": [
                     [
@@ -136,7 +136,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz:md5,0a629e1745926cfcedf4b169046a921a"
+                        "test_out.g.vcf.gz:md5,89b2e47883a65bb9cae8f173e782bb17"
                     ]
                 ],
                 "gvcf_tbi": [
@@ -145,7 +145,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz.tbi:md5,49503913c28ec70a6f4aa52f6b357b4d"
+                        "test_out.g.vcf.gz.tbi:md5,1680c67fe988bc1d8220fbb4127c2c18"
                     ]
                 ],
                 "vcf": [
@@ -154,7 +154,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz:md5,8b8ab4a675f01e437aa72e1438a717d0"
+                        "test_out.vcf.gz:md5,707212230030c8c3efbe5c2e0428da03"
                     ]
                 ],
                 "vcf_tbi": [
@@ -163,19 +163,19 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz.tbi:md5,0000833138104e87b05eaa906821eb21"
+                        "test_out.vcf.gz.tbi:md5,248648ca03f5fda904ebbef8821e0e37"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a251d8d9f5e8b737d8298eead96c0890"
+                    "versions.yml:md5,3609b8b1430f8fa9038d70e359be0056"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2024-08-29T11:34:41.779153"
+        "timestamp": "2025-05-14T07:59:47.319639829"
     },
     "homo_sapiens - [cram, crai, genome_bed] - fasta - fai": {
         "content": [
@@ -186,7 +186,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz:md5,8b8ab4a675f01e437aa72e1438a717d0"
+                        "test_out.vcf.gz:md5,707212230030c8c3efbe5c2e0428da03"
                     ]
                 ],
                 "1": [
@@ -195,7 +195,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz.tbi:md5,0000833138104e87b05eaa906821eb21"
+                        "test_out.vcf.gz.tbi:md5,248648ca03f5fda904ebbef8821e0e37"
                     ]
                 ],
                 "2": [
@@ -204,7 +204,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz:md5,0a629e1745926cfcedf4b169046a921a"
+                        "test_out.g.vcf.gz:md5,89b2e47883a65bb9cae8f173e782bb17"
                     ]
                 ],
                 "3": [
@@ -213,11 +213,11 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz.tbi:md5,49503913c28ec70a6f4aa52f6b357b4d"
+                        "test_out.g.vcf.gz.tbi:md5,1680c67fe988bc1d8220fbb4127c2c18"
                     ]
                 ],
                 "4": [
-                    "versions.yml:md5,a251d8d9f5e8b737d8298eead96c0890"
+                    "versions.yml:md5,3609b8b1430f8fa9038d70e359be0056"
                 ],
                 "gvcf": [
                     [
@@ -225,7 +225,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz:md5,0a629e1745926cfcedf4b169046a921a"
+                        "test_out.g.vcf.gz:md5,89b2e47883a65bb9cae8f173e782bb17"
                     ]
                 ],
                 "gvcf_tbi": [
@@ -234,7 +234,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz.tbi:md5,49503913c28ec70a6f4aa52f6b357b4d"
+                        "test_out.g.vcf.gz.tbi:md5,1680c67fe988bc1d8220fbb4127c2c18"
                     ]
                 ],
                 "vcf": [
@@ -243,7 +243,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz:md5,8b8ab4a675f01e437aa72e1438a717d0"
+                        "test_out.vcf.gz:md5,707212230030c8c3efbe5c2e0428da03"
                     ]
                 ],
                 "vcf_tbi": [
@@ -252,19 +252,19 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz.tbi:md5,0000833138104e87b05eaa906821eb21"
+                        "test_out.vcf.gz.tbi:md5,248648ca03f5fda904ebbef8821e0e37"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a251d8d9f5e8b737d8298eead96c0890"
+                    "versions.yml:md5,3609b8b1430f8fa9038d70e359be0056"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2024-08-29T11:35:16.993129"
+        "timestamp": "2025-05-14T08:00:05.147083931"
     },
     "homo_sapiens - [cram, crai, genome_bed] - fasta - fai - par_bed": {
         "content": [
@@ -275,7 +275,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz:md5,d2e26d65dbbcea9b087ed191b5c9841c"
+                        "test_out.vcf.gz:md5,b3d1a03998c435d8c37be7c9c868f3c0"
                     ]
                 ],
                 "1": [
@@ -284,7 +284,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz.tbi:md5,0801296d0356415bbf1ef8deb4ec84c3"
+                        "test_out.vcf.gz.tbi:md5,d57a16c0fda381a7bf659789d889a9d4"
                     ]
                 ],
                 "2": [
@@ -293,7 +293,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz:md5,4fcaa9a8b55730d191382160c2b5bb0a"
+                        "test_out.g.vcf.gz:md5,61833a909ae1bc176b47a5afc9fdc517"
                     ]
                 ],
                 "3": [
@@ -302,11 +302,11 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz.tbi:md5,f468e846904733b3231ecf00ef7cd4a2"
+                        "test_out.g.vcf.gz.tbi:md5,673ce95e6701a5e7d58ea2ab93440b27"
                     ]
                 ],
                 "4": [
-                    "versions.yml:md5,a251d8d9f5e8b737d8298eead96c0890"
+                    "versions.yml:md5,3609b8b1430f8fa9038d70e359be0056"
                 ],
                 "gvcf": [
                     [
@@ -314,7 +314,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz:md5,4fcaa9a8b55730d191382160c2b5bb0a"
+                        "test_out.g.vcf.gz:md5,61833a909ae1bc176b47a5afc9fdc517"
                     ]
                 ],
                 "gvcf_tbi": [
@@ -323,7 +323,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.g.vcf.gz.tbi:md5,f468e846904733b3231ecf00ef7cd4a2"
+                        "test_out.g.vcf.gz.tbi:md5,673ce95e6701a5e7d58ea2ab93440b27"
                     ]
                 ],
                 "vcf": [
@@ -332,7 +332,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz:md5,d2e26d65dbbcea9b087ed191b5c9841c"
+                        "test_out.vcf.gz:md5,b3d1a03998c435d8c37be7c9c868f3c0"
                     ]
                 ],
                 "vcf_tbi": [
@@ -341,18 +341,18 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_out.vcf.gz.tbi:md5,0801296d0356415bbf1ef8deb4ec84c3"
+                        "test_out.vcf.gz.tbi:md5,d57a16c0fda381a7bf659789d889a9d4"
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,a251d8d9f5e8b737d8298eead96c0890"
+                    "versions.yml:md5,3609b8b1430f8fa9038d70e359be0056"
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.6"
         },
-        "timestamp": "2024-08-29T11:35:52.23093"
+        "timestamp": "2025-05-14T08:00:22.927680542"
     }
 }

--- a/modules/nf-core/deepvariant/rundeepvariant/tests/tags.yml
+++ b/modules/nf-core/deepvariant/rundeepvariant/tests/tags.yml
@@ -1,2 +1,0 @@
-deepvariant/rundeepvariant:
-  - modules/nf-core/deepvariant/rundeepvariant/**


### PR DESCRIPTION
DeepVariant was upgraded to **v1.9.0**, with the `--vcf-stats-report` flag added to run command in `deepvariant/rundeepvariant/main.nf` to generate the visual report (auto-generated in v1.6.1).

So far we should notice:
- `--vcf-stats-report`: now required to generate the visual report (automatically generated in v1.6.1)
- `--disable_small_model`: optional if prefer to use the standard model  
Since v1.8.0, DeepVariant defaults to using an additional **small model** for easy-to-call sites. With test samples, VCFs does not show significant differences compared to the standard model, just with slightly higher **GQ** and **QUAL** scores. Thus, this option is currently not stated in run command.

Tested with the `test` profile (data for `test_full` is not available). Overall, output structures are similar between the two versions. Summary of observed differences between v1.6.1 and v1.9.0 (consistent across test samples):
- Lower **QUAL**/**GQ** scores (stricter confidence calibration)
- Improved detection of complex and multiallelic variants
- `0/0` calls by 1.6.0 are `./.` uncalled by 1.9.0
- Additional FORMAT fields: `PS`, `MF`, `MD`, `MT` (supporting phasing and methylation-aware analysis)
More detailed result investigation is available [here](https://docs.google.com/presentation/d/1wA7Lg9XbuCibl8_pKuHOpPRwXmOPTPbPVUiHyiBgG6M/edit?usp=sharing).
These differences reflect model upgrades introduced in v1.8.0 (Platinum Pedigree training, SPRQ chemistry). For more details, see the [DeepVariant release notes](https://github.com/google/deepvariant/releases).

Another note is that header of VCFs from dev branch before update said that version is 1.6.0 (instead of 1.6.1)
##DeepVariant_version=1.6.0
