### PR TITLE
bugfix: the information is in the ch_genome_index_fai channel

### DIFF
--- a/subworkflows/local/deepvariant_caller.nf
+++ b/subworkflows/local/deepvariant_caller.nf
@@ -99,10 +99,14 @@ workflow DEEPVARIANT_CALLER {
 
     // index the compressed files in two formats for maximum compatibility (each has its own limitation)
     // select the type of index to use based on the maximum sequence length
-    tabix_selector  = ch_compressed_vcf.branch { meta, vcf ->
+    ch_compressed_vcf
+    .combine(max_length)
+    .branch { meta_vcf, vcf, meta ->
         tbi_and_csi: meta.max_length < 2**29
         only_csi:    meta.max_length < 2**32
     }
+    .set { tabix_selector }
+
     // do the indexing on the compatible gvcf files
     ch_indexed_vcf_csi = TABIX_CSI ( tabix_selector.tbi_and_csi.mix(tabix_selector.only_csi) ).csi
     ch_versions        = ch_versions.mix ( TABIX_CSI.out.versions.first() )


### PR DESCRIPTION
Hi.

There's a bug in your implementation of the CSI/TBI selector. It's looking at a meta map that doesn't have the right keys. If you search `max_length` in the file you'll see it's just declared as input but not used anywhere.

To check that the selector really work, just change the thresholds to something very small like 100, and you should see the processes don't run

Matthieu


<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
