### PR TITLE
Combine metas of vcf and mex_length in deepvariant_caller.nf

### DIFF
--- a/subworkflows/local/deepvariant_caller.nf
+++ b/subworkflows/local/deepvariant_caller.nf
@@ -101,7 +101,8 @@ workflow DEEPVARIANT_CALLER {
     // select the type of index to use based on the maximum sequence length
     ch_compressed_vcf
     .combine(max_length)
-    .branch { meta_vcf, vcf, meta ->
+    .map { meta_vcf, vcf, meta -> [ meta_vcf + meta, vcf ] }
+    .branch { meta, vcf ->
         tbi_and_csi: meta.max_length < 2**29
         only_csi:    meta.max_length < 2**32
     }


### PR DESCRIPTION
The `tabix` modules generate warning messages on input tuple. It expects two elements (meta, vcf) but there're three (meta, vcf, meta of max_length).

Combined the metas in subworkflow/local/Deepvariant_caller.

<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
