### PR TITLE
Combine metas of vcf and max_length in deepvariant_caller.nf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[1.1.8](https://github.com/sanger-tol/variantcalling/releases/tag/1.1.8)] - Shang Tang (patch 8) - [2025-07-03]
+
+### Enhancements & fixes
+
+- Fix bug in subworkflow deepvariant_caller
+
 ## [[1.1.7](https://github.com/sanger-tol/variantcalling/releases/tag/1.1.7)] - Shang Tang (patch 7) - [2025-06-26]
 
 ### Enhancements & fixes

--- a/nextflow.config
+++ b/nextflow.config
@@ -267,7 +267,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'main'
     nextflowVersion = '!>=23.10.1'
-    version         = '1.1.7'
+    version         = '1.1.8'
     doi             = '10.5281/zenodo.7890527'
 }
 

--- a/subworkflows/local/deepvariant_caller.nf
+++ b/subworkflows/local/deepvariant_caller.nf
@@ -105,7 +105,7 @@ workflow DEEPVARIANT_CALLER {
         .branch { meta, vcf ->
             tbi_and_csi: meta.max_length < 2**29
             only_csi:    meta.max_length < 2**32
-    }
+        }
         .set { tabix_selector }
 
     // do the indexing on the compatible gvcf files

--- a/subworkflows/local/deepvariant_caller.nf
+++ b/subworkflows/local/deepvariant_caller.nf
@@ -101,7 +101,8 @@ workflow DEEPVARIANT_CALLER {
     // select the type of index to use based on the maximum sequence length
     ch_compressed_vcf
     .combine(max_length)
-    .branch { meta_vcf, vcf, meta ->
+    .map { meta_vcf, vcf, meta -> [ meta_vcf + meta, vcf ] }
+    .branch { meta, vcf ->
         tbi_and_csi: meta.max_length < 2**29
         only_csi:    meta.max_length < 2**32
     }

--- a/subworkflows/local/deepvariant_caller.nf
+++ b/subworkflows/local/deepvariant_caller.nf
@@ -100,13 +100,13 @@ workflow DEEPVARIANT_CALLER {
     // index the compressed files in two formats for maximum compatibility (each has its own limitation)
     // select the type of index to use based on the maximum sequence length
     ch_compressed_vcf
-    .combine(max_length)
-    .map { meta_vcf, vcf, meta -> [ meta_vcf + meta, vcf ] }
-    .branch { meta, vcf ->
-        tbi_and_csi: meta.max_length < 2**29
-        only_csi:    meta.max_length < 2**32
+        .combine(max_length)
+        .map { meta_vcf, vcf, meta -> [ meta_vcf + meta, vcf ] }
+        .branch { meta, vcf ->
+            tbi_and_csi: meta.max_length < 2**29
+            only_csi:    meta.max_length < 2**32
     }
-    .set { tabix_selector }
+        .set { tabix_selector }
 
     // do the indexing on the compatible gvcf files
     ch_indexed_vcf_csi = TABIX_CSI ( tabix_selector.tbi_and_csi.mix(tabix_selector.only_csi) ).csi

--- a/workflows/variantcalling.nf
+++ b/workflows/variantcalling.nf
@@ -23,7 +23,7 @@ if (params.fai){
         ||
         ( !params.fasta.endsWith('.gz') && params.fai.endsWith('.gzi') )
     ){
-      exit 1, 'Reference fasta and its index file format not matched!'
+        exit 1, 'Reference fasta and its index file format not matched!'
     }
     ch_fai = Channel.fromPath(params.fai)
 } else {
@@ -85,9 +85,9 @@ workflow VARIANTCALLING {
 
     ch_versions = Channel.empty()
     ch_fasta
-     .map { fasta -> [ [ 'id': fasta.baseName -  ~/.fa\w*$/ , 'genome_size': fasta.size() ], fasta ] }
-     .first()
-     .set { ch_genome }
+        .map { fasta -> [ [ 'id': fasta.baseName -  ~/.fa\w*$/ , 'genome_size': fasta.size() ], fasta ] }
+        .first()
+        .set { ch_genome }
 
     //
     // check reference fasta index given or not
@@ -95,18 +95,18 @@ workflow VARIANTCALLING {
 
     if( params.fai == null ){
 
-       SAMTOOLS_FAIDX ( ch_genome,  [[], []] )
-       ch_versions = ch_versions.mix( SAMTOOLS_FAIDX.out.versions )
+        SAMTOOLS_FAIDX ( ch_genome,  [[], []] )
+        ch_versions = ch_versions.mix( SAMTOOLS_FAIDX.out.versions )
 
-       // generate fai that is used to determine the maximum length of chromosome
-       ch_genome_index_fai = SAMTOOLS_FAIDX.out.fai
-       ch_genome_index = params.fasta.endsWith('.gz') ? SAMTOOLS_FAIDX.out.gzi : SAMTOOLS_FAIDX.out.fai
+        // generate fai that is used to determine the maximum length of chromosome
+        ch_genome_index_fai = SAMTOOLS_FAIDX.out.fai
+        ch_genome_index = params.fasta.endsWith('.gz') ? SAMTOOLS_FAIDX.out.gzi : SAMTOOLS_FAIDX.out.fai
 
     }else{
-       ch_fai
-        .map { fai -> [ [ 'id': fai.baseName ], fai ] }
-        .first()
-        .set { ch_genome_index }
+        ch_fai
+            .map { fai -> [ [ 'id': fai.baseName ], fai ] }
+            .first()
+            .set { ch_genome_index }
 
         ch_genome_index_fai  = ch_genome_index
         if ( !params.fai.endsWith(".fai") ) {
@@ -116,8 +116,8 @@ workflow VARIANTCALLING {
     }
 
     ch_genome_index_fai
-     .map { meta, index -> [ [ id: meta.id ] + get_sequence_map(index) ] }
-     .set { ch_genome_info }
+        .map { meta, index -> [ [ id: meta.id ] + get_sequence_map(index) ] }
+        .set { ch_genome_info }
 
     //
     // SUBWORKFLOW: Read in samplesheet, validate and stage input files
@@ -200,8 +200,8 @@ workflow VARIANTCALLING {
     // convert VCF channel meta id
     //
     DEEPVARIANT_CALLER.out.vcf
-     .map{ meta, vcf -> [ [ id: vcf.baseName ], vcf ] }
-     .set{ vcf }
+        .map{ meta, vcf -> [ [ id: vcf.baseName ], vcf ] }
+        .set{ vcf }
 
     //
     // process VCF output files


### PR DESCRIPTION
The tabix modules generate warning messages on input tuple. It expects two elements (meta, vcf) but there're three (meta, vcf, meta of max_length).

Combined the metas in subworkflow/local/Deepvariant_caller.

<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
