### PR TITLE
Template upgrade mm49

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,8 +23,7 @@ If you're not used to this workflow with git, you can start with some [docs from
 
 ## Tests
 
-You have the option to test your changes locally by running the pipeline. For receiving warnings about process selectors and other `debug` information, it is recommended to use the debug profile.
-Execute all the tests with the following command:
+You have the option to test your changes locally by running the pipeline. For receiving warnings about process selectors and other `debug` information, it is recommended to use the debug profile. Execute all the tests with the following command:
 
 ```bash
 nf-test test --profile debug,test,docker --verbose
@@ -53,9 +52,9 @@ These tests are run both with the latest available version of `Nextflow` and als
 
 :warning: Only in the unlikely and regretful event of a release happening with a bug.
 
-- On your own fork, make a new branch `patch` based on `upstream/main`.
+- On your own fork, make a new branch `patch` based on `upstream/main` or `upstream/master`.
 - Fix the bug, and bump version (X.Y.Z+1).
-- A PR should be made on `main` from patch to directly this particular bug.
+- Open a pull-request from `patch` to `main`/`master` with the changes.
 
 ## Pipeline contribution conventions
 

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,15 +1,17 @@
 name: nf-core branch protection
-# This workflow is triggered on PRs to main branch on the repository
-# It fails when someone tries to make a PR against the nf-core `main` branch instead of `dev`
+# This workflow is triggered on PRs to `main`/`master` branch on the repository
+# It fails when someone tries to make a PR against the nf-core `main`/`master` branch instead of `dev`
 on:
   pull_request_target:
-    branches: [main]
+    branches:
+      - main
+      - master
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      # PRs to the nf-core repo main branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
+      # PRs to the nf-core repo main/master branch are only ok if coming from the nf-core repo `dev` or any `patch` branches
       - name: Check PRs
         if: github.repository == 'sanger-tol/variantcalling'
         run: |
@@ -35,7 +37,7 @@ jobs:
             It looks like this pull-request is has been made against the [${{github.event.pull_request.head.repo.full_name }}](https://github.com/${{github.event.pull_request.head.repo.full_name }}) ${{github.event.pull_request.base.ref}} branch.
             The ${{github.event.pull_request.base.ref}} branch on nf-core repositories should always contain code from the latest release.
             Because of this, PRs to ${{github.event.pull_request.base.ref}} are only allowed if they come from the [${{github.event.pull_request.head.repo.full_name }}](https://github.com/${{github.event.pull_request.head.repo.full_name }}) `dev` branch.
-            
+
             You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
             Note that even after this, the test will continue to show as failing until you push a new commit.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             profile: "singularity"
     steps:
       - name: Check out pipeline code
-        uses: uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
         run: |
           echo $(realpath $CONDA)/condabin >> $GITHUB_PATH
           echo $(realpath python) >> $GITHUB_PATH
-      
+
       - name: Clean up Disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
 

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ secrets.sangertolsoft_access_token }}
-      
+
       # indication that the linting is being fixed
       - name: React on comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
@@ -40,13 +40,13 @@ jobs:
         run: pip install pre-commit
 
       - name: Run pre-commit
-        id: pre_commit
+        id: pre-commit
         run: pre-commit run --all-files
         continue-on-error: true
 
       # indication that the linting has finished
       - name: react if linting finished succesfully
-        if: steps.pre_commit.outcome == 'success'
+        if: steps.pre-commit.outcome == 'success'
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           comment-id: ${{ github.event.comment.id }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -61,7 +61,7 @@ jobs:
         run: nf-core -l lint_log.txt pipelines lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
 
       - name: Run nf-core pipelines lint --release
-        if: ${{ github.base_ref != 'main' }}
+        if: ${{ github.base_ref == 'main' }}
         env:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -46,16 +46,16 @@
 
 - [Bioconda](https://pubmed.ncbi.nlm.nih.gov/29967506/)
 
-  > Grüning B, Dale R, Sjödin A, Chapman BA, Rowe J, Tomkins-Tinch CH, Valieris R, Köster J; Bioconda Team. Bioconda: sustainable and comprehensive software distribution for the life sciences. Nat Me 5(7):475-476. doi: 10.1038/s41592-018-0046-7. PubMed PMID: 29967506.
+  > Grüning B, Dale R, Sjödin A, Chapman BA, Rowe J, Tomkins-Tinch CH, Valieris R, Köster J; Bioconda Team. Bioconda: sustainable and comprehensive software distribution for the life sciences. Nat Methods. 2018 Jul;15(7):475-476. doi: 10.1038/s41592-018-0046-7. PubMed PMID: 29967506.
 
 - [BioContainers](https://pubmed.ncbi.nlm.nih.gov/28379341/)
 
-  > da Veiga Leprevost F, Grüning B, Aflitos SA, Röst HL, Uszkoreit J, Barsnes H, Vaudel M, Moreno P, Gatto L, Weber J, Bai M, Jimenez RC, Sachsenberg T, Pfeuffer J, Alvarez RV, Griss J, Nesvizhskii Y. BioContainers: an open-source and community-driven framework for software standardization. Bioinformatics. 2017 Aug 15;33(16):2580-2582. doi: 10.1093/bioinformatics/btx192. PubMed PMID: 28379341; CID: PMC5870671.
+  > da Veiga Leprevost F, Grüning B, Aflitos SA, Röst HL, Uszkoreit J, Barsnes H, Vaudel M, Moreno P, Gatto L, Weber J, Bai M, Jimenez RC, Sachsenberg T, Pfeuffer J, Alvarez RV, Griss J, Nesvizhskii AI, Perez-Riverol Y. BioContainers: an open-source and community-driven framework for software standardization. Bioinformatics. 2017 Aug 15;33(16):2580-2582. doi: 10.1093/bioinformatics/btx192. PubMed PMID: 28379341; PubMed Central PMCID: PMC5870671.
 
-- [Docker][Docker](https://dl.acm.org/doi/10.5555/2600239.2600241)
+- [Docker](https://dl.acm.org/doi/10.5555/2600239.2600241)
 
   > Merkel, D. (2014). Docker: lightweight linux containers for consistent development and deployment. Linux Journal, 2014(239), 2. doi: 10.5555/2600239.2600241.
 
 - [Singularity](https://pubmed.ncbi.nlm.nih.gov/28494014/)
 
-  > Kurtzer GM, Sochat V, Bauer MW. Singularity: Scientific containers for mobility of compute. PLoS One. 2017 May 11;12(5):e0177459. doi: 10.1371/journal.pone.0177459. eCollection 2017. PubMed PMID: Central PMCID: PMC5426675.
+  > Kurtzer GM, Sochat V, Bauer MW. Singularity: Scientific containers for mobility of compute. PLoS One. 2017 May 11;12(5):e0177459. doi: 10.1371/journal.pone.0177459. eCollection 2017. PubMed PMID: 28494014; PubMed Central PMCID: PMC5426675.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Genome Research Ltd.
+Copyright (c) 2023-2025 Genome Research Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/assets/email_template.html
+++ b/assets/email_template.html
@@ -3,6 +3,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
   <meta name="description" content="sanger-tol/variantcalling: Variant calling pipeline for PacBio data using DeepVariant">
   <title>sanger-tol/variantcalling Pipeline Report</title>
 </head>

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -20,6 +20,7 @@
             },
             "datafile": {
                 "type": "string",
+                "exists": true,
                 "pattern": "^\\S+\\.(bam|cram)$",
                 "errorMessage": "Data file for reads cannot contain spaces and must have extension 'cram' or 'bam'"
             }

--- a/assets/slackreport.json
+++ b/assets/slackreport.json
@@ -3,7 +3,7 @@
         {
             "fallback": "Plain-text summary of the attachment.",
             "color": "<% if (success) { %>good<% } else { %>danger<%} %>",
-            "author_name": "sanger-tol/variantcalling v${version} - ${runName}",
+            "author_name": "sanger-tol/variantcalling ${version} - ${runName}",
             "author_icon": "https://www.nextflow.io/docs/latest/_static/favicon.ico",
             "text": "<% if (success) { %>Pipeline completed successfully!<% } else { %>Pipeline completed with errors<% } %>",
             "fields": [

--- a/conf/test_align.config
+++ b/conf/test_align.config
@@ -10,14 +10,17 @@
 ----------------------------------------------------------------------------------------
 */
 
+process {
+    resourceLimits = [
+        cpus: 4,
+        memory: '15.GB',
+        time: '1.h'
+    ]
+}
+
 params {
     config_profile_name        = 'Test profile with alignment'
     config_profile_description = 'Minimal unaligned test dataset to check pipeline function'
-
-    // Limit resources so that this can run on GitHub Actions
-    max_cpus   = 2
-    max_memory = '6.GB'
-    max_time   = '6.h'
 
     // Input data
     input  = "${projectDir}/assets/samplesheet_test_align.csv"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ The pipeline takes aligned or unaliged sample reads (CRAM/BAM files) from a CSV 
 
 ## Samplesheet input
 
-You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use the `input` parameter to specify the samplesheet location. It has to be a comma-separated file with 3 columns, and a header row as shown in the examples below.
+You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row as shown in the examples below.
 
 ```bash
 --input '[path to samplesheet file]'
@@ -18,7 +18,7 @@ You will need to create a samplesheet with information about the samples you wou
 
 The `sample` identifiers have to be the same when you have re-sequenced the same sample more than once e.g. to increase sequencing depth. Below is an example for the same sample sequenced across 3 lanes:
 
-```console
+```csv title="samplesheet.csv"
 sample,datatype,datafile
 sample1,pacbio,sample1_1.cram
 sample1,pacbio,sample1_2.cram
@@ -29,7 +29,7 @@ sample1,pacbio,sample1_3.cram
 
 A final samplesheet file consisting of both BAM or CRAM will look like this. Currently this pipeline only supports Pacbio aligned data.
 
-```console
+```csv title="samplesheet.csv"
 sample,datatype,datafile
 sample1,pacbio,/path/to/data/file/file1.bam
 sample2,pacbio,/path/to/data/file/file2.cram
@@ -49,7 +49,7 @@ An [example samplesheet](../assets/samplesheet.csv) has been provided with the p
 The typical command for running the pipeline is as follows:
 
 ```bash
-nextflow run sanger-tol/variantcalling --input samplesheet.csv --outdir <OUTDIR> --fasta genome.fasta.gz -profile docker
+nextflow run sanger-tol/variantcalling --input ./samplesheet.csv --outdir ./results --fasta genome.fasta.gz  -profile docker
 ```
 
 This will launch the pipeline with the `docker` configuration profile. See below for more information about profiles.
@@ -105,7 +105,7 @@ First, go to the [sanger-tol/variantcalling releases page](https://github.com/sa
 
 This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future.
 
-To further assist in reproducibility, you can use share and re-use [parameter files](#running-the-pipeline) to repeat pipeline runs with the same settings without having to write out a command with every single parameter.
+To further assist in reproducibility, you can use share and reuse [parameter files](#running-the-pipeline) to repeat pipeline runs with the same settings without having to write out a command with every single parameter.
 
 > [!TIP]
 > If you wish to share such profile (such as upload as supplementary material for academic publications), make sure to NOT include cluster specific paths to files, nor institutional specific profiles.

--- a/nextflow.config
+++ b/nextflow.config
@@ -302,6 +302,32 @@ validation {
         command = "nextflow run sanger-tol/variantcalling -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
         fullParameter = "help_full"
         showHiddenParameter = "show_hidden"
+        beforeText = """
+-\033[2m----------------------------------------------------\033[0m-
+\033[0;34m   _____                               \033[0;32m _______   \033[0;31m _\033[0m
+\033[0;34m  / ____|                              \033[0;32m|__   __|  \033[0;31m| |\033[0m
+\033[0;34m | (___   __ _ _ __   __ _  ___ _ __ \033[0m ___ \033[0;32m| |\033[0;33m ___ \033[0;31m| |\033[0m
+\033[0;34m  \\___ \\ / _` | '_ \\ / _` |/ _ \\ '__|\033[0m|___|\033[0;32m| |\033[0;33m/ _ \\\033[0;31m| |\033[0m
+\033[0;34m  ____) | (_| | | | | (_| |  __/ |        \033[0;32m| |\033[0;33m (_) \033[0;31m| |____\033[0m
+\033[0;34m |_____/ \\__,_|_| |_|\\__, |\\___|_|        \033[0;32m|_|\033[0;33m\\___/\033[0;31m|______|\033[0m
+\033[0;34m                      __/ |\033[0m
+\033[0;34m                     |___/\033[0m
+\033[0;35m  ${manifest.name} ${manifest.version}\033[0m
+-\033[2m----------------------------------------------------\033[0m-
+"""
+        afterText = """${manifest.doi ? "\n* The pipeline\n" : ""}${manifest.doi.tokenize(",").collect { "    https://doi.org/${it.trim().replace('https://doi.org/','')}"}.join("\n")}${manifest.doi ? "\n" : ""}
+* The nf-core framework
+    https://doi.org/10.1038/s41587-020-0439-x
+* Software dependencies
+    https://github.com/sanger-tol/variantcalling/blob/main/CITATIONS.md
+"""
+    }
+    summary {
+        beforeText = validation.help.beforeText
+        afterText = validation.help.afterText
+    }
+}
+
     }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,33 +45,10 @@ params {
 
     // Schema validation default options
     validate_params            = true
-
-    // Max resource options
-    // Defaults only, expecting to be overwritten
-    max_memory                 = '128.GB'
-    max_cpus                   = 16
-    max_time                   = '240.h'
-
 }
 
 // Load base.config by default for all pipelines
 includeConfig 'conf/base.config'
-
-// Load nf-core custom profiles from different Institutions
-try {
-    includeConfig "${params.custom_config_base}/nfcore_custom.config"
-} catch (Exception e) {
-    System.err.println("WARNING: Could not load nf-core/config profiles: ${params.custom_config_base}/nfcore_custom.config")
-}
-
-// Load sanger-tol/variantcalling custom profiles from different institutions.
-// Warning: Uncomment only if a pipeline-specific instititutional config already exists on nf-core/configs!
-// try {
-//   includeConfig "${params.custom_config_base}/pipeline/variantcalling.config"
-// } catch (Exception e) {
-//   System.err.println("WARNING: Could not load nf-core/config/variantcalling profiles: ${params.custom_config_base}/pipeline/variantcalling.config")
-// }
-
 
 profiles {
 
@@ -83,7 +60,6 @@ profiles {
         cleanup                 = false
         nextflow.enable.configProcessNamesValidation = true
     }
-
     conda {
         conda.enabled           = true
         docker.enabled          = false
@@ -118,15 +94,15 @@ profiles {
         docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'
     }
     singularity {
-        singularity.enabled    = true
-        singularity.autoMounts = true
-        singularity.registry   = 'quay.io'
-        conda.enabled          = false
-        docker.enabled         = false
-        podman.enabled         = false
-        shifter.enabled        = false
-        charliecloud.enabled   = false
-        apptainer.enabled      = false
+        singularity.enabled     = true
+        singularity.autoMounts  = true
+        singularity.registry    = 'quay.io'
+        conda.enabled           = false
+        docker.enabled          = false
+        podman.enabled          = false
+        shifter.enabled         = false
+        charliecloud.enabled    = false
+        apptainer.enabled       = false
     }
     podman {
         podman.enabled          = true
@@ -189,6 +165,22 @@ profiles {
     test_full       { includeConfig 'conf/test_full.config'       }
     test_full_align { includeConfig 'conf/test_full_align.config' }
 }
+
+// Load nf-core custom profiles from different Institutions
+includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/nfcore_custom.config" : "/dev/null"
+
+// Load sanger-tol/variantcalling custom profiles from different institutions.
+// TODO nf-core: Optionally, you can add a pipeline-specific nf-core config at https://github.com/nf-core/configs
+// includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/pipeline/variantcalling.config" : "/dev/null"
+
+// Set default registry for Apptainer, Docker, Podman, Charliecloud and Singularity independent of -profile
+// Will not be used unless Apptainer / Docker / Podman / Charliecloud / Singularity are enabled
+// Set to your registry if you have a mirror of containers
+apptainer.registry    = 'quay.io'
+docker.registry       = 'quay.io'
+podman.registry       = 'quay.io'
+singularity.registry  = 'quay.io'
+charliecloud.registry = 'quay.io'
 
 
 
@@ -291,7 +283,7 @@ manifest {
     description     = """Variant calling pipeline for PacBio data using DeepVariant"""
     mainScript      = 'main.nf'
     defaultBranch   = 'main'
-    nextflowVersion = '!>=23.10.1'
+    nextflowVersion = '!>=24.04.2'
     version         = '1.1.9'
     doi             = '10.5281/zenodo.7890527'
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -219,6 +219,7 @@ report {
 trace {
     enabled = true
     file    = "${params.outdir}/pipeline_info/execution_trace_${params.trace_report_suffix}.txt"
+    fields  = 'task_id,hash,native_id,process,tag,status,exit,cpus,memory,time,attempt,submit,start,complete,duration,%cpu,%mem,peak_rss,rchar,wchar'
 }
 dag {
     enabled = true

--- a/tower.yml
+++ b/tower.yml
@@ -1,3 +1,3 @@
 reports:
   samplesheet.csv:
-    display: "Auto-created samplesheet with collated metadata and aligned file paths."
+    display: "Auto-created samplesheet with collated metadata and FASTQ paths"

--- a/workflows/variantcalling.nf
+++ b/workflows/variantcalling.nf
@@ -255,22 +255,6 @@ def get_sequence_map(fai_file) {
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    COMPLETION EMAIL AND SUMMARY
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-workflow.onComplete {
-    if (params.email || params.email_on_fail) {
-        NfcoreTemplate.email(workflow, params, summary_params, projectDir, log)
-    }
-    NfcoreTemplate.summary(workflow, params, log)
-    if (params.hook_url) {
-        NfcoreTemplate.IM_notification(workflow, params, summary_params, projectDir, log)
-    }
-}
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     THE END
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */


### PR DESCRIPTION
Hi Yunjia,

I've started reviewing #124

The first commit here is essentially about restoring some files as they were in the TEMPLATE branch. For instance, nf-core are accepting both `main` and `master`. Even if we only have `main`, and what you put in the `.github/*` _is_ correct, it's better to keep the nf-core version. Minimising differences with the TEMPLATE branch means the future template upgrades will be easier.
 
The other commits are adaptations to make based on features of the new template 

<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
