### PR TITLE
Sort the BAM files to guarantee the order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to nf-core template version 3.5.1
 - Removed the process_vcf sub-workflow, which is now in a new pipeline called
   [variantcomposition](https://github.com/sanger-tol/variantcomposition).
+- When merging reads from multiple runs, order the read files by metadata
+  information to ensure reproducibility.
 
 ### Software dependencies
 

--- a/subworkflows/local/align_pacbio.nf
+++ b/subworkflows/local/align_pacbio.nf
@@ -29,8 +29,14 @@ workflow ALIGN_PACBIO {
 
     // Collect all alignment output by sample name
     ch_bams = MINIMAP2_ALIGN.out.bam
-        .map { meta, bam -> [['id': meta.sample, 'datatype': meta.datatype, 'sample': meta.sample], bam] }
+        .map { meta, bam -> [['id': meta.sample, 'datatype': meta.datatype, 'sample': meta.sample], [meta.id, bam]] }
         .groupTuple(by: [0])
+        .map { meta, orig_id_bams ->
+            def bams = orig_id_bams
+                .sort { a, b -> a[0] <=> b[0]} // sort by id to ensure consistent order
+                .collect { id_bam -> id_bam[1] }
+            [meta, bams]
+        }
 
 
     // Merge

--- a/tests/align.nf.test.snap
+++ b/tests/align.nf.test.snap
@@ -53,7 +53,7 @@
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.vcf.gz:md5,c3145668dc0fe2cc98a97a1e14345649"
             ],
             [
-                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1.cram:md5,8687ba1f97f527df6dda7b5ad73b245e",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1.cram:md5,e34a3e0c89e931b165c6f45317fc044a",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1XXXXX.cram:md5,49774288f3270c0d31fc7139a1f33a49"
             ]
         ],
@@ -61,6 +61,6 @@
             "nf-test": "0.9.3",
             "nextflow": "25.10.2"
         },
-        "timestamp": "2026-04-12T15:02:37.79923157"
+        "timestamp": "2026-04-13T21:17:22.217235894"
     }
 }


### PR DESCRIPTION
CI was a bit flaky and I realised it was always `test_align` complaining about a checksum, but not always.

The problem was due to the BAMs being concatenated in a random order.
Here I order according to their `id`, which guarantees it is the same across runs. 

<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
