### PR TITLE
Removed the --fai parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | ------------------- | ------------- |
 | --include_positions |               |
 | --exclude_positions |               |
+| --fai               |               |
 
 > **NB:** Parameter has been **updated** if both old and new parameter information is present. </br> **NB:** Parameter has been **added** if just the new parameter information is present. </br> **NB:** Parameter has been **removed** if new parameter information isn't present.
 

--- a/conf/test.config
+++ b/conf/test.config
@@ -28,10 +28,6 @@ params {
     // Fasta references
     fasta                      = 'https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/assembly/GCA_947369205.1_OX376310.1_CANBKR010000003.1.fasta.gz'
 
-    // Reference index file (optional)
-    // fai = 'https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/assembly/GCA_947369205.1_OX376310.1_CANBKR010000003.1.fasta.gz.fai'
-    // fai = 'https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/assembly/GCA_947369205.1_OX376310.1_CANBKR010000003.1.fasta.gz.gzi'
-
     // Interval bed file
     interval                   = 'https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bed'
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -19,7 +19,4 @@ params {
 
     // Fasta references
     fasta                      = '/lustre/scratch122/tol/data/1/f/4/a/0/9/Cantharis_rufa/assembly/release/icCanRufa1.1/insdc/GCA_947369205.1.fasta.gz'
-
-    // Reference index file
-    fai                        = '/lustre/scratch122/tol/data/1/f/4/a/0/9/Cantharis_rufa/assembly/release/icCanRufa1.1/insdc/GCA_947369205.1.fasta.gz.gzi'
 }

--- a/main.nf
+++ b/main.nf
@@ -29,7 +29,6 @@ workflow SANGERTOL_VARIANTCALLING {
     take:
     input // channel: samplesheet read in from --input
     fasta
-    fai
     interval
 
     main:
@@ -40,7 +39,6 @@ workflow SANGERTOL_VARIANTCALLING {
     VARIANTCALLING(
         input,
         fasta,
-        fai,
         interval,
     )
 }
@@ -65,7 +63,6 @@ workflow {
         params.help_full,
         params.show_hidden,
         params.fasta,
-        params.fai,
         params.interval,
     )
 
@@ -75,7 +72,6 @@ workflow {
     SANGERTOL_VARIANTCALLING(
         PIPELINE_INITIALISATION.out.input,
         PIPELINE_INITIALISATION.out.fasta,
-        PIPELINE_INITIALISATION.out.fai,
         PIPELINE_INITIALISATION.out.interval,
     )
     //

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,6 @@ params {
     // Input options
     input                        = null
     fasta                        = null
-    fai                          = null
     align                        = false
     interval                     = null
     split_fasta_cutoff           = 100000

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -56,12 +56,6 @@
                     "description": "Path to FASTA genome file, either fasta or fasta.gz.",
                     "format": "file-path"
                 },
-                "fai": {
-                    "type": "string",
-                    "description": "Path to the index file of the FASTA genome file, either fai or gzi.",
-                    "format": "file-path",
-                    "exists": true
-                },
                 "align": {
                     "type": "boolean",
                     "description": "Align the input reads to the reference"

--- a/subworkflows/local/align_pacbio.nf
+++ b/subworkflows/local/align_pacbio.nf
@@ -10,7 +10,7 @@ include { CONVERT_STATS  } from '../../subworkflows/local/convert_stats'
 
 workflow ALIGN_PACBIO {
     take:
-    fasta // channel: [ val(meta), /path/to/fasta ]
+    fasta // channel: [ val(meta), /path/to/fasta[.gz] ]
     reads // channel: [ val(meta), /path/to/datafile ]
     db // channel: /path/to/vector_db
 

--- a/subworkflows/local/convert_stats.nf
+++ b/subworkflows/local/convert_stats.nf
@@ -11,7 +11,7 @@ include { SAMTOOLS_IDXSTATS } from '../../modules/nf-core/samtools/idxstats/main
 workflow CONVERT_STATS {
     take:
     bam // channel: [ val(meta), /path/to/bam, /path/to/bai]
-    fasta // channel: [ val(meta), /path/to/fasta ]
+    fasta // channel: [ val(meta), /path/to/fasta[.gz] ]
 
     main:
     ch_versions = channel.empty()

--- a/subworkflows/local/input_filter_split.nf
+++ b/subworkflows/local/input_filter_split.nf
@@ -9,7 +9,7 @@ include { SAMTOOLS_VIEW  } from '../../modules/nf-core/samtools/view/main'
 
 workflow INPUT_FILTER_SPLIT {
     take:
-    fasta // [ val(meta, /path/to/genome.fasta[.gz] ]
+    fasta // [ val(meta, /path/to/fasta[.gz] ]
     reads // [ val(meta), data, index ]
     interval // file: /path/to/intervals.bed
 

--- a/subworkflows/local/input_filter_split.nf
+++ b/subworkflows/local/input_filter_split.nf
@@ -9,7 +9,7 @@ include { SAMTOOLS_VIEW  } from '../../modules/nf-core/samtools/view/main'
 
 workflow INPUT_FILTER_SPLIT {
     take:
-    fasta // [ val(meta, /path/to/fasta[.gz] ]
+    fasta // [ val(meta), /path/to/fasta[.gz] ]
     reads // [ val(meta), data, index ]
     interval // file: /path/to/intervals.bed
 

--- a/subworkflows/local/input_merge.nf
+++ b/subworkflows/local/input_merge.nf
@@ -7,8 +7,8 @@ include { SAMTOOLS_SORT  } from '../../modules/nf-core/samtools/sort'
 
 workflow INPUT_MERGE {
     take:
-    fasta // channel: [ val(meta), /path/to/genome.fasta or /path/to/genome.fasta.gz ]
-    fai // channel: [ val(meta), /path/to/genome.*.fai or /path/to/genome.fasta.gz.gzi ]
+    fasta // channel: [ val(meta), /path/to/fasta[.gz] ]
+    fai // channel: [ val(meta), /path/to/[fai,gzi] ]
     reads // channel: [ val(meta), data ]
 
     main:

--- a/subworkflows/local/utils_nfcore_variantcalling_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_variantcalling_pipeline/main.nf
@@ -36,7 +36,6 @@ workflow PIPELINE_INITIALISATION {
     help_full // boolean: Show the full help message
     show_hidden // boolean: Show hidden parameters in the help message
     fasta
-    fai
     _interval
 
     main:
@@ -108,17 +107,6 @@ workflow PIPELINE_INITIALISATION {
     // Creat channel for mandatory parameters
     ch_fasta = channel.fromPath(fasta)
 
-    // Creat channel for optional parameters
-    if (params.fai) {
-        if ((params.fasta.endsWith('.gz') && params.fai.endsWith('.fai')) || (!params.fasta.endsWith('.gz') && params.fai.endsWith('.gzi'))) {
-            exit(1, 'Reference fasta and its index file format not matched!')
-        }
-        ch_fai = channel.fromPath(fai)
-    }
-    else {
-        ch_fai = channel.empty()
-    }
-
     if (params.interval) {
         ch_interval = channel.fromPath(params.interval)
     }
@@ -129,7 +117,6 @@ workflow PIPELINE_INITIALISATION {
     emit:
     input     = ch_validated_samplesheet
     fasta     = ch_fasta
-    fai       = ch_fai
     interval  = ch_interval
     versions  = ch_versions
 }

--- a/workflows/variantcalling.nf
+++ b/workflows/variantcalling.nf
@@ -55,6 +55,7 @@ workflow VARIANTCALLING {
 
 
     SAMTOOLS_FAIDX(ch_genome, [[], []])
+    ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
 
     // generate fai that is used to determine the maximum length of chromosome
     // also add the gzi if present as it is needed for bgzip-ed genomes

--- a/workflows/variantcalling.nf
+++ b/workflows/variantcalling.nf
@@ -54,32 +54,16 @@ workflow VARIANTCALLING {
     }
 
 
-    //
-    // Check reference fasta index given or not
-    //
-    if (!params.fai) {
+    SAMTOOLS_FAIDX(ch_genome, [[], []])
 
-        SAMTOOLS_FAIDX(ch_genome, [[], []])
-        ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
-
-        // generate fai that is used to determine the maximum length of chromosome
-        ch_genome_index_fai = SAMTOOLS_FAIDX.out.fai
-        ch_genome_index = params.fasta.endsWith('.gz') ? SAMTOOLS_FAIDX.out.gzi : SAMTOOLS_FAIDX.out.fai
-    }
-    else {
-        ch_genome_index = ch_fai.map { fai -> [['id': fai.baseName], fai] }
-
-        ch_genome_index_fai = ch_genome_index
-        if (!params.fai.endsWith(".fai")) {
-            ch_genome_index_fai = SAMTOOLS_FAIDX(ch_genome, [[], []]).fai
-            ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
-        }
-    }
-
+    // generate fai that is used to determine the maximum length of chromosome
+    // also add the gzi if present as it is needed for bgzip-ed genomes
     ch_genome_info = ch_genome
-        .combine(ch_genome_index_fai)
-        .map { meta_fa, fa, _meta_fai, fai ->
-            [meta_fa + get_sequence_map(fai), fa, fai]
+       .join( SAMTOOLS_FAIDX.out.fai )
+       .join( SAMTOOLS_FAIDX.out.gzi, remainder: true )
+       .map { meta, fa, fai, gzi ->
+           def index_file = fa.name.endsWith('.gz') ? [fai, gzi] : fai
+           [meta + get_sequence_map(fai), fa, index_file]
         }
         .collect()
         .multiMap { meta, fa, fai ->

--- a/workflows/variantcalling.nf
+++ b/workflows/variantcalling.nf
@@ -33,7 +33,6 @@ workflow VARIANTCALLING {
     take:
     ch_reads // channel: samplesheet read in from --input
     ch_fasta // channel: fasta file read in from --fasta
-    ch_fai // channel: fai file read in from --fai
     ch_interval // channel: interval file read in from --interval
 
     main:

--- a/workflows/variantcalling.nf
+++ b/workflows/variantcalling.nf
@@ -62,7 +62,7 @@ workflow VARIANTCALLING {
        .join( SAMTOOLS_FAIDX.out.fai )
        .join( SAMTOOLS_FAIDX.out.gzi, remainder: true )
        .map { meta, fa, fai, gzi ->
-           def index_file = fa.name.endsWith('.gz') ? [fai, gzi] : fai
+           def index_file = (fa.name.endsWith('.gz') && gzi) ? [fai, gzi] : fai
            [meta + get_sequence_map(fai), fa, index_file]
         }
         .collect()


### PR DESCRIPTION
In reality we need two indexes for samtools: fai and gzi. We decided to remove gzi in v1.1 to make the code simpler, but now it's in a half-baked state: sometimes there's no gzi and the pipeline fails, sometimes the fai is re-generated even if there was one already.

Removing all for now and letting the pipeline compute fresh indexes. In a future, I'd like to add support for implicit .fai and .gzi, just like samtools does.

<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
