### PR TITLE
Flag homozygous alternative genotypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements & fixes
 
 - Support gzipped FASTA
+- Added a `--flag_hom_alts` option to flag homozygous alternative genotypes
+
+### Parameters
+
+| Old parameter | New parameter   |
+| ------------- | --------------- |
+|               | --flag_hom_alts |
+
+> **NB:** Parameter has been **updated** if both old and new parameter information is present. </br> **NB:** Parameter has been **added** if just the new parameter information is present. </br> **NB:** Parameter has been **removed** if new parameter information isn't present.
 
 ## [[2.0.1](https://github.com/sanger-tol/variantcalling/releases/tag/2.0.1)] - Qin Shi Huang (patch 1) - [2026-05-15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support gzipped FASTA
 - Added a `--flag_hom_alts` option to flag homozygous alternative genotypes
+- In alignment mode, the SAMTOOLS_STATS output is now compressed in gzip format
 
 ### Parameters
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -140,4 +140,13 @@ process {
         ]
     }
 
+    withName: FLAG_HOM_ALTS {
+        ext.args = { "-i 'GT=\"AA\"' -s '${params.flag_hom_alts}' -Oz --write-index" }
+        ext.prefix = { "${meta.basename}.deepvariant.hom_alts" }
+        publishDir = [
+            path: { "${params.outdir}/variant_analysis/${meta.type}/${meta.sample}/qc" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+        ]
+    }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -102,7 +102,7 @@ process {
 
     withName: '.*:DEEPVARIANT_CALLER:DEEPVARIANT' {
         ext.prefix = { "${meta.id}.${meta2.id}" }
-        ext.args = { "--model_type=PACBIO ${params.deepvariant_parameters ?: ''}" }
+        ext.args = { "--model_type=PACBIO ${params.deepvariant_parameters ?: ''} --sample_name ${meta.sample}" }
     }
 
     withName: '.*:DEEPVARIANT_CALLER:BCFTOOLS_CONCAT_VCF' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -73,7 +73,15 @@ process {
         ]
     }
 
-    withName: '.*:ALIGN_PACBIO:CONVERT_STATS:SAMTOOLS_.*STAT.*' {
+    withName: '.*:ALIGN_PACBIO:CONVERT_STATS:(SAMTOOLS_FLAGSTAT|SAMTOOLS_IDXSTATS)' {
+        publishDir = [
+            path: { "${params.outdir}/read_mapping/${meta.datatype}/${meta.sample}/stats" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+        ]
+    }
+
+    withName: '.*:ALIGN_PACBIO:CONVERT_STATS:PIGZ_COMPRESS' {
         publishDir = [
             path: { "${params.outdir}/read_mapping/${meta.datatype}/${meta.sample}/stats" },
             mode: params.publish_dir_mode,

--- a/conf/test.config
+++ b/conf/test.config
@@ -28,6 +28,9 @@ params {
     // Fasta references
     fasta                      = 'https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/assembly/GCA_947369205.1_OX376310.1_CANBKR010000003.1.fasta.gz'
 
+    // Extra bcftools view
+    flag_hom_alts              = 'SAMEA7521030/merge'
+
     // Interval bed file
     intervals                  = 'https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bed'
 }

--- a/conf/test_align.config
+++ b/conf/test_align.config
@@ -26,6 +26,9 @@ params {
     input                      = "${projectDir}/assets/samplesheet_test_align.csv"
     align                      = true
 
+    // Extra bcftools view
+    flag_hom_alts              = 'SAMEA7521030_X/ERR10224927_02_2'
+
     // Fasta references in gzip format
     fasta                      = "https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/assembly/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.fasta.gz"
 }

--- a/docs/output.md
+++ b/docs/output.md
@@ -63,6 +63,7 @@ The aligned PacBio read data is used to call variants with DeepVariant. This is 
       - Index of compressed GVCF files: `<fasta_basename>.pacbio.<sample>.minimap2.deepvariant.g.vcf.gz.[tbi|csi]`.
       - `qc`
         - HTML files: `<fasta_basename>.pacbio.<sample>.minimap2.deepvariant.[vcf|g.vcf].stats.visual_report.html`.
+        - Homozygous alternative genotypes report: `<fasta_basename>.pacbio.<sample>.minimap2.deepvariant.hom_alts.vcf.gz[.tbi]` (optional).
 
 </details>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,6 +54,15 @@ otherwise the pipeline's own parameter validation will consider it a sanger-tol/
 nextflow run ... --deepvariant_parameters " --make_examples_extra_args='small_model_call_multiallelics=false'"
 ```
 
+## QC
+
+The pipeline outputs include a HTML report from DeepVariant.
+
+There is also a `--flag_hom_alts` that can be used to generate a VCF file with
+homozygous alternative genotypes for that sample.
+The option is useful when calling variant on the same sample as used for the
+genome assembly, as in theory all its variants should be heterozygous.
+
 ## Running the pipeline
 
 The typical command for running the pipeline is as follows:

--- a/modules.json
+++ b/modules.json
@@ -41,6 +41,11 @@
                         "git_sha": "5c9f8d5b7671237c906abadc9ff732b301ca15ca",
                         "installed_by": ["modules"]
                     },
+                    "pigz/compress": {
+                        "branch": "master",
+                        "git_sha": "c908ccaf0a5c802b6f8e814d8c5cf85da2364222",
+                        "installed_by": ["modules"]
+                    },
                     "samtools/collate": {
                         "branch": "master",
                         "git_sha": "156feda0cb6589cd29c04902004fa3b53bc00205",

--- a/modules.json
+++ b/modules.json
@@ -10,6 +10,11 @@
                         "git_sha": "4b21e2cd1a9ea70e22b502cb45ee147410824760",
                         "installed_by": ["modules"]
                     },
+                    "bcftools/view": {
+                        "branch": "master",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "installed_by": ["modules"]
+                    },
                     "blast/blastn": {
                         "branch": "master",
                         "git_sha": "3a9acfe9865ac6f63bc48667657bfb8293613f56",

--- a/modules/nf-core/bcftools/view/environment.yml
+++ b/modules/nf-core/bcftools/view/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/htslib
+  - bioconda::htslib=1.23.1
+  # renovate: datasource=conda depName=bioconda/bcftools
+  - bioconda::bcftools=1.23.1

--- a/modules/nf-core/bcftools/view/main.nf
+++ b/modules/nf-core/bcftools/view/main.nf
@@ -1,0 +1,76 @@
+process BCFTOOLS_VIEW {
+    tag "${meta.id}"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0b/0b4d52ca9a56d07be3f78a12af654e5116f5112908dba277e6796fd9dfb83fe5/data'
+        : 'community.wave.seqera.io/library/bcftools_htslib:1.23.1--9f08ec665533d64a'}"
+
+    input:
+    tuple val(meta), path(vcf), path(index)
+    path regions
+    path targets
+    path samples
+
+    output:
+    tuple val(meta), path("*.{vcf,vcf.gz,bcf,bcf.gz}"), emit: vcf
+    tuple val(meta), path("*.tbi"), emit: tbi, optional: true
+    tuple val(meta), path("*.csi"), emit: csi, optional: true
+    tuple val("${task.process}"), val('bcftools'), eval("bcftools --version | sed '1!d; s/^.*bcftools //'"), topic: versions, emit: versions_bcftools
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def regions_file = regions ? "--regions-file ${regions}" : ""
+    def targets_file = targets ? "--targets-file ${targets}" : ""
+    def samples_file = samples ? "--samples-file ${samples}" : ""
+    def extension = args.contains("--output-type b") || args.contains("-Ob")
+        ? "bcf.gz"
+        : args.contains("--output-type u") || args.contains("-Ou")
+            ? "bcf"
+            : args.contains("--output-type z") || args.contains("-Oz")
+                ? "vcf.gz"
+                : args.contains("--output-type v") || args.contains("-Ov")
+                    ? "vcf"
+                    : "vcf"
+    """
+    bcftools view \\
+        --output ${prefix}.${extension} \\
+        ${regions_file} \\
+        ${targets_file} \\
+        ${samples_file} \\
+        ${args} \\
+        --threads ${task.cpus} \\
+        ${vcf}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = args.contains("--output-type b") || args.contains("-Ob")
+        ? "bcf.gz"
+        : args.contains("--output-type u") || args.contains("-Ou")
+            ? "bcf"
+            : args.contains("--output-type z") || args.contains("-Oz")
+                ? "vcf.gz"
+                : args.contains("--output-type v") || args.contains("-Ov")
+                    ? "vcf"
+                    : "vcf"
+    def stub_index = args.contains("--write-index=tbi") || args.contains("-W=tbi")
+        ? "tbi"
+        : args.contains("--write-index=csi") || args.contains("-W=csi")
+            ? "csi"
+            : args.contains("--write-index") || args.contains("-W")
+                ? "csi"
+                : ""
+    def create_cmd = extension.endsWith(".gz") ? "echo '' | gzip >" : "touch"
+    def create_index = extension.endsWith(".gz") && stub_index.matches("csi|tbi") ? "touch ${prefix}.${extension}.${stub_index}" : ""
+    """
+    ${create_cmd} ${prefix}.${extension}
+    ${create_index}
+    """
+}

--- a/modules/nf-core/bcftools/view/meta.yml
+++ b/modules/nf-core/bcftools/view/meta.yml
@@ -1,0 +1,112 @@
+name: bcftools_view
+description: View, subset and filter VCF or BCF files by position and filtering expression.
+  Convert between VCF and BCF
+keywords:
+  - variant calling
+  - view
+  - bcftools
+  - VCF
+tools:
+  - view:
+      description: |
+        View, subset and filter VCF or BCF files by position and filtering expression. Convert between VCF and BCF
+      homepage: http://samtools.github.io/bcftools/bcftools.html
+      documentation: http://www.htslib.org/doc/bcftools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
+      identifier: biotools:bcftools
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - vcf:
+        type: file
+        description: |
+          The vcf file to be inspected.
+          e.g. 'file.vcf'
+        ontologies: []
+    - index:
+        type: file
+        description: |
+          The tab index for the VCF file to be inspected.
+          e.g. 'file.tbi'
+        ontologies: []
+  - regions:
+      type: file
+      description: |
+        Optionally, restrict the operation to regions listed in this file.
+        e.g. 'file.vcf'
+      ontologies: []
+  - targets:
+      type: file
+      description: |
+        Optionally, restrict the operation to regions listed in this file (doesn't rely upon index files)
+        e.g. 'file.vcf'
+      ontologies: []
+  - samples:
+      type: file
+      description: |
+        Optional, file of sample names to be included or excluded.
+        e.g. 'file.tsv'
+      ontologies: []
+output:
+  vcf:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.{vcf,vcf.gz,bcf,bcf.gz}":
+          type: file
+          description: VCF normalized output file
+          pattern: "*.{vcf,vcf.gz,bcf,bcf.gz}"
+          ontologies: []
+  tbi:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.tbi":
+          type: file
+          description: Alternative VCF file index
+          pattern: "*.tbi"
+          ontologies: []
+  csi:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.csi":
+          type: file
+          description: Default VCF file index
+          pattern: "*.csi"
+          ontologies: []
+  versions_bcftools:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bcftools:
+          type: string
+          description: The tool name
+      - "bcftools --version | sed '1!d; s/^.*bcftools //'":
+          type: string
+          description: The command used to generate the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bcftools:
+          type: string
+          description: The tool name
+      - "bcftools --version | sed '1!d; s/^.*bcftools //'":
+          type: string
+          description: The command used to generate the version of the tool
+authors:
+  - "@abhi18av"
+maintainers:
+  - "@abhi18av"

--- a/modules/nf-core/bcftools/view/tests/main.nf.test
+++ b/modules/nf-core/bcftools/view/tests/main.nf.test
@@ -1,0 +1,288 @@
+nextflow_process {
+
+    name "Test Process BCFTOOLS_VIEW"
+    script "../main.nf"
+    process "BCFTOOLS_VIEW"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bcftools"
+    tag "bcftools/view"
+
+    test("sarscov2 - [vcf, tbi], [], [], []") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index") {
+
+        config "./vcf_gz_index.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.tbi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_csi") {
+
+        config "./vcf_gz_index_csi.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.tbi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_tbi") {
+
+        config "./vcf_gz_index_tbi.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.csi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.tbi.collect { it.collect { it instanceof Map ? it : file(it).name } },
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() },
+                { assert process.out.tbi[0][1].endsWith(".tbi") }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], vcf, tsv, []") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true)
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.targets.tsv.gz', checkIfExists: true)
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.vcf,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - stub") {
+
+        config "./nextflow.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.vcf[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index - stub") {
+
+        config "./vcf_gz_index.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_csi - stub") {
+
+        config "./vcf_gz_index_csi.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.csi[0][1].endsWith(".csi") }
+            )
+        }
+    }
+
+    test("sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_tbi - stub") {
+
+        config "./vcf_gz_index_tbi.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'out', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() },
+                { assert process.out.tbi[0][1].endsWith(".tbi") }
+            )
+        }
+    }
+}

--- a/modules/nf-core/bcftools/view/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/view/tests/main.nf.test.snap
@@ -1,0 +1,393 @@
+{
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_csi - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:23:46.101707716",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_tbi": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz.tbi"
+                ]
+            ],
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:23:10.374165894",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "csi": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.csi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tbi": [
+                    
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:23:37.664960008",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_tbi - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ],
+                "csi": [
+                    
+                ],
+                "tbi": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz.tbi:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "vcf": [
+                    [
+                        {
+                            "id": "out",
+                            "single_end": false
+                        },
+                        "out_vcf.vcf.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
+                    ]
+                ],
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:23:54.823465363",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], vcf, tsv, []": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out.vcf:md5,1bcbd0eff25d316ba915d06463aab17b"
+                ]
+            ],
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:23:19.908213867",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - stub": {
+        "content": [
+            "out.vcf",
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:23:28.40103319",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz.csi"
+                ]
+            ],
+            [
+                
+            ],
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:22:53.951814647",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], []": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out.vcf:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:22:45.088231326",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    },
+    "sarscov2 - [vcf, tbi], [], [], [] - vcf_gz_index_csi": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz:md5,8e722884ffb75155212a3fc053918766"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "out",
+                        "single_end": false
+                    },
+                    "out_vcf.vcf.gz.csi"
+                ]
+            ],
+            [
+                
+            ],
+            {
+                "versions_bcftools": [
+                    [
+                        "BCFTOOLS_VIEW",
+                        "bcftools",
+                        "1.23.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-20T18:23:02.014904437",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.2"
+        }
+    }
+}

--- a/modules/nf-core/bcftools/view/tests/nextflow.config
+++ b/modules/nf-core/bcftools/view/tests/nextflow.config
@@ -1,0 +1,3 @@
+process {
+    ext.args = '--no-version --output-type v'
+}

--- a/modules/nf-core/bcftools/view/tests/vcf_gz_index.config
+++ b/modules/nf-core/bcftools/view/tests/vcf_gz_index.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index --no-version"
+}

--- a/modules/nf-core/bcftools/view/tests/vcf_gz_index_csi.config
+++ b/modules/nf-core/bcftools/view/tests/vcf_gz_index_csi.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index=csi --no-version"
+}

--- a/modules/nf-core/bcftools/view/tests/vcf_gz_index_tbi.config
+++ b/modules/nf-core/bcftools/view/tests/vcf_gz_index_tbi.config
@@ -1,0 +1,4 @@
+process {
+    ext.prefix = { "${meta.id}_vcf" }
+    ext.args = "--output-type z --write-index=tbi --no-version"
+}

--- a/modules/nf-core/pigz/compress/environment.yml
+++ b/modules/nf-core/pigz/compress/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - pigz=2.8

--- a/modules/nf-core/pigz/compress/main.nf
+++ b/modules/nf-core/pigz/compress/main.nf
@@ -1,0 +1,34 @@
+process PIGZ_COMPRESS {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/pigz:2.8':
+        'biocontainers/pigz:2.8' }"
+
+    input:
+    tuple val(meta), path(raw_file)
+
+    output:
+    tuple val(meta), path("$archive"), emit: archive
+    tuple val("${task.process}"), val('pigz'), eval('pigz --version 2>&1 | sed "s/^.*pigz[[:space:]]*//"'), emit: versions_pigz, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    archive = raw_file.toString() + ".gz"
+    """
+    # Note: needs --stdout for pigz to avoid the following issue:
+    #   pigz: skipping: ${raw_file} is a symbolic link
+    pigz --processes $task.cpus --stdout --force ${args} ${raw_file} > ${archive}
+    """
+
+    stub:
+    archive = raw_file.toString() + ".gz"
+    """
+    touch ${archive}
+    """
+}

--- a/modules/nf-core/pigz/compress/meta.yml
+++ b/modules/nf-core/pigz/compress/meta.yml
@@ -1,0 +1,64 @@
+name: "pigz_compress"
+description: Compresses files with pigz.
+keywords:
+  - compress
+  - gzip
+  - parallelized
+tools:
+  - "pigz":
+      description: "Parallel implementation of the gzip algorithm."
+      homepage: "https://zlib.net/pigz/"
+      documentation: "https://zlib.net/pigz/pigz.pdf"
+      licence: ["Zlib"]
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+    - raw_file:
+        type: file
+        description: File to be compressed
+        pattern: "*.*"
+        ontologies: []
+output:
+  archive:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - $archive:
+          type: file
+          description: The compressed file
+          pattern: "*.gz"
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  versions_pigz:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pigz:
+          type: string
+          description: The name of the tool
+      - pigz --version 2>&1 | sed "s/^.*pigz[[:space:]]*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pigz:
+          type: string
+          description: The name of the tool
+      - pigz --version 2>&1 | sed "s/^.*pigz[[:space:]]*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+authors:
+  - "@leoisl"
+maintainers:
+  - "@leoisl"

--- a/modules/nf-core/pigz/compress/tests/main.nf.test
+++ b/modules/nf-core/pigz/compress/tests/main.nf.test
@@ -1,0 +1,55 @@
+nextflow_process {
+    name "Test Process PIGZ_COMPRESS"
+    script "../main.nf"
+    process "PIGZ_COMPRESS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "pigz"
+    tag "pigz/compress"
+
+    test("sarscov2 - genome - fasta") {
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test'], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.archive,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - genome - fasta - stub") {
+        options "-stub-run"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test'], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                """
+            }
+        }
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.archive[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/pigz/compress/tests/main.nf.test.snap
+++ b/modules/nf-core/pigz/compress/tests/main.nf.test.snap
@@ -1,0 +1,47 @@
+{
+    "sarscov2 - genome - fasta": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "genome.fasta.gz:md5,6e9fe4042a72f2345f644f239272b7e6"
+                ]
+            ],
+            {
+                "versions_pigz": [
+                    [
+                        "PIGZ_COMPRESS",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-28T17:50:46.437661"
+    },
+    "sarscov2 - genome - fasta - stub": {
+        "content": [
+            "genome.fasta.gz",
+            {
+                "versions_pigz": [
+                    [
+                        "PIGZ_COMPRESS",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-28T17:50:57.213069"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,11 +14,12 @@ params {
     fasta                        = null
     align                        = false
     filter_pacbio                = true
-    deepvariant_parameters      = null
+    deepvariant_parameters       = null
     intervals                    = null
     split_fasta_cutoff           = 100000
     vector_db                    = "${projectDir}/assets/vectorDB.tar.gz"
     merge_output                 = "merge"
+    flag_hom_alts                = null
 
     // Boilerplate options
     outdir                       = 'results'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -48,6 +48,12 @@
                     "description": "Non-empty string used as the suffix and output directory name for merged data files",
                     "help_text": "Defines the suffix added to merged file names and name of output directory when multiple read files that share the same specimen are merged. Allowed characters are letters, numbers, dot (.), underscore (_), and hyphen (-)."
                 },
+                "flag_hom_alts": {
+                    "type": "string",
+                    "pattern": "^\\S+$",
+                    "description": "Name of the sample, specimen, or run, for which to flag homozygous alternative genotypes. The suffix '/merge' can be used in conjunction with --merge_output.",
+                    "help_text": "When the reads come from the same individual as used to make the genome assembly, we only expect homozygous reference and heterozygous calls"
+                },
                 "email": {
                     "type": "string",
                     "description": "Email address for completion summary.",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -52,7 +52,7 @@
                     "type": "string",
                     "pattern": "^\\S+$",
                     "description": "Name of the sample, specimen, or run, for which to flag homozygous alternative genotypes. The suffix '/merge' can be used in conjunction with --merge_output.",
-                    "help_text": "When the reads come from the same individual as used to make the genome assembly, we only expect homozygous reference and heterozygous calls"
+                    "help_text": "When the reads come from the same individual as used to make the genome assembly, we only expect homozygous reference and heterozygous calls. This option writes an extra VCF file with these calls."
                 },
                 "email": {
                     "type": "string",

--- a/subworkflows/local/convert_stats.nf
+++ b/subworkflows/local/convert_stats.nf
@@ -6,6 +6,7 @@ include { SAMTOOLS_VIEW     } from '../../modules/nf-core/samtools/view/main'
 include { SAMTOOLS_STATS    } from '../../modules/nf-core/samtools/stats/main'
 include { SAMTOOLS_FLAGSTAT } from '../../modules/nf-core/samtools/flagstat/main'
 include { SAMTOOLS_IDXSTATS } from '../../modules/nf-core/samtools/idxstats/main'
+include { PIGZ_COMPRESS     } from '../../modules/nf-core/pigz/compress/main'
 
 
 workflow CONVERT_STATS {
@@ -25,6 +26,7 @@ workflow CONVERT_STATS {
     // Calculate statistics
     SAMTOOLS_STATS(ch_cram_crai, fasta)
 
+    PIGZ_COMPRESS(SAMTOOLS_STATS.out.stats)
 
     // Calculate statistics based on flag values
     SAMTOOLS_FLAGSTAT(ch_cram_crai)

--- a/tests/align.nf.test.snap
+++ b/tests/align.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_align": {
         "content": [
-            57,
+            59,
             {
                 "BCFTOOLS_CONCAT_GVCF": {
                     "bcftools": "1.23.1"
@@ -30,6 +30,9 @@
                 },
                 "PACBIO_FILTER": {
                     "gawk": "5.1.0"
+                },
+                "PIGZ_COMPRESS": {
+                    "pigz": 2.8
                 },
                 "SAMTOOLS_COLLATE": {
                     "samtools": "1.23.1"
@@ -90,7 +93,7 @@
                 "read_mapping/pacbio/SAMEA7521030/merge/stats",
                 "read_mapping/pacbio/SAMEA7521030/merge/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.flagstat",
                 "read_mapping/pacbio/SAMEA7521030/merge/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.idxstats",
-                "read_mapping/pacbio/SAMEA7521030/merge/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.stats",
+                "read_mapping/pacbio/SAMEA7521030/merge/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.stats.gz",
                 "read_mapping/pacbio/SAMEA7521030_X",
                 "read_mapping/pacbio/SAMEA7521030_X/ERR10224927_02_2",
                 "read_mapping/pacbio/SAMEA7521030_X/ERR10224927_02_2/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.cram",
@@ -98,7 +101,7 @@
                 "read_mapping/pacbio/SAMEA7521030_X/ERR10224927_02_2/stats",
                 "read_mapping/pacbio/SAMEA7521030_X/ERR10224927_02_2/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.flagstat",
                 "read_mapping/pacbio/SAMEA7521030_X/ERR10224927_02_2/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.idxstats",
-                "read_mapping/pacbio/SAMEA7521030_X/ERR10224927_02_2/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.stats",
+                "read_mapping/pacbio/SAMEA7521030_X/ERR10224927_02_2/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.stats.gz",
                 "variant_analysis",
                 "variant_analysis/pacbio",
                 "variant_analysis/pacbio/SAMEA7521030",
@@ -126,16 +129,18 @@
                 "variant_analysis/pacbio/SAMEA7521030_X/ERR10224927_02_2/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.vcf.gz.tbi",
                 "variant_analysis/pacbio/SAMEA7521030_X/ERR10224927_02_2/qc",
                 "variant_analysis/pacbio/SAMEA7521030_X/ERR10224927_02_2/qc/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.g.vcf.stats.visual_report.html",
+                "variant_analysis/pacbio/SAMEA7521030_X/ERR10224927_02_2/qc/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.hom_alts.vcf.gz",
+                "variant_analysis/pacbio/SAMEA7521030_X/ERR10224927_02_2/qc/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.hom_alts.vcf.gz.csi",
                 "variant_analysis/pacbio/SAMEA7521030_X/ERR10224927_02_2/qc/GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.vcf.stats.visual_report.html"
             ],
             [
                 "SOURCE.txt:md5,4cb3ee552cdc244156debe9965d43154",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.flagstat:md5,46d82921bb895f051b6a82658c18286f",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.idxstats:md5,7be1ca471671613630279bd5179b558f",
-                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.stats:md5,33c9284481eaadf7813857ac32fce4ad",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.stats.gz:md5,33c9284481eaadf7813857ac32fce4ad",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.flagstat:md5,2c5d67733407c8eddc2a7d59e035606e",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.idxstats:md5,122ade711785188461e196872324044b",
-                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.stats:md5,16a7605db4f3ba1ade72ff9fe3a32946",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.stats.gz:md5,16a7605db4f3ba1ade72ff9fe3a32946",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.deepvariant.g.vcf.stats.visual_report.html:md5,9f575012bae052d888fa6f1a29b0ee9e",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.deepvariant.vcf.stats.visual_report.html:md5,d15483ca19af84878e7bf1da5f312015",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.g.vcf.stats.visual_report.html:md5,ee14416e2322acc7861940d065eb10f2",
@@ -152,7 +157,7 @@
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.cram:md5,49774288f3270c0d31fc7139a1f33a49"
             ]
         ],
-        "timestamp": "2026-06-04T09:43:36.352008407",
+        "timestamp": "2026-06-04T15:14:55.560270085",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.2"

--- a/tests/align.nf.test.snap
+++ b/tests/align.nf.test.snap
@@ -136,10 +136,10 @@
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.flagstat:md5,2c5d67733407c8eddc2a7d59e035606e",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.idxstats:md5,122ade711785188461e196872324044b",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.stats:md5,16a7605db4f3ba1ade72ff9fe3a32946",
-                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.deepvariant.g.vcf.stats.visual_report.html:md5,1117b5cda9236daaefe3871935008167",
-                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.deepvariant.vcf.stats.visual_report.html:md5,ad3a47d3df72cd7694f366abdc0925e7",
-                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.g.vcf.stats.visual_report.html:md5,6c59d428a1c6c91fbbd368940b1c701d",
-                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.vcf.stats.visual_report.html:md5,6058a1bcf9630d159ad193ed76dac334"
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.deepvariant.g.vcf.stats.visual_report.html:md5,9f575012bae052d888fa6f1a29b0ee9e",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.deepvariant.vcf.stats.visual_report.html:md5,d15483ca19af84878e7bf1da5f312015",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.g.vcf.stats.visual_report.html:md5,ee14416e2322acc7861940d065eb10f2",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.vcf.stats.visual_report.html:md5,69d09bbe4a8e3f21840fe7292d440c9d"
             ],
             [
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.deepvariant.g.vcf.gz:md5,6faaf6ecf0b7c5cc664d2da6f9a1069b",
@@ -152,10 +152,10 @@
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.cram:md5,49774288f3270c0d31fc7139a1f33a49"
             ]
         ],
-        "timestamp": "2026-05-18T14:39:16.760383",
+        "timestamp": "2026-06-04T09:43:36.352008407",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.2"
+            "nextflow": "25.10.2"
         }
     }
 }

--- a/tests/align.nf.test.snap
+++ b/tests/align.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_align": {
         "content": [
-            59,
+            60,
             {
                 "BCFTOOLS_CONCAT_GVCF": {
                     "bcftools": "1.23.1"
@@ -18,6 +18,9 @@
                 },
                 "DEEPVARIANT": {
                     "deepvariant": "1.10.0"
+                },
+                "FLAG_HOM_ALTS": {
+                    "bcftools": "1.23.1"
                 },
                 "GUNZIP": {
                     "gunzip": 1.13
@@ -150,6 +153,7 @@
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.deepvariant.g.vcf.gz:md5,6faaf6ecf0b7c5cc664d2da6f9a1069b",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.deepvariant.vcf.gz:md5,f3230403ec480904033694159f064800",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.g.vcf.gz:md5,a82bcaa26c16328cf19b72beee49b80d",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.hom_alts.vcf.gz:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.vcf.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -92,13 +92,13 @@
             ],
             [
                 "SOURCE.txt:md5,e30fa0754f9d79d9279413bdbb5fec9c",
-                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.stats.visual_report.html:md5,2a5c7e1a9ba325d175cf9ad1e410c6c7",
-                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.stats.visual_report.html:md5,68eb791e98d22eee398aeb35eef2be33",
+                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.stats.visual_report.html:md5,132668ce8de3c05e02488faccf7e80ca",
+                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.stats.visual_report.html:md5,ed31adac8869dbdcc777fd3e06a27edc",
                 "SOURCE.txt:md5,6749ca92d21ea1ce5fe427932de02583",
-                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.stats.visual_report.html:md5,2a5c7e1a9ba325d175cf9ad1e410c6c7",
-                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.stats.visual_report.html:md5,68eb791e98d22eee398aeb35eef2be33",
-                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.stats.visual_report.html:md5,4258fda623c3a1c5e50338a4819763a6",
-                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.stats.visual_report.html:md5,57289fbb7ebe57e9c845454b6287b5dc"
+                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.stats.visual_report.html:md5,160fa42422803b27c9354e8bd021a182",
+                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.stats.visual_report.html:md5,56fd377ced50936b2d8bec5a16c6f817",
+                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.stats.visual_report.html:md5,214a30f8de2bf2cb2b4d76850e7b9255",
+                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.stats.visual_report.html:md5,25a25144e1490a2887cf39fc47c9b6bd"
             ],
             [
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.gz:md5,a7a3df91599b390b501cf2b807f560eb",
@@ -109,10 +109,10 @@
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.gz:md5,54531cd87ddea9810409d6c6143786ac"
             ]
         ],
-        "timestamp": "2026-05-07T12:27:31.990126",
+        "timestamp": "2026-06-04T09:47:02.695910333",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.2"
+            "nextflow": "25.10.2"
         }
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test": {
         "content": [
-            35,
+            36,
             {
                 "BCFTOOLS_CONCAT_GVCF": {
                     "bcftools": "1.23.1"
@@ -15,6 +15,9 @@
                 },
                 "DEEPVARIANT": {
                     "deepvariant": "1.10.0"
+                },
+                "FLAG_HOM_ALTS": {
+                    "bcftools": "1.23.1"
                 },
                 "GUNZIP": {
                     "gunzip": 1.13
@@ -62,6 +65,8 @@
                 "variant_analysis/pacbio/SAMEA7521030/merge/SOURCE.txt",
                 "variant_analysis/pacbio/SAMEA7521030/merge/qc",
                 "variant_analysis/pacbio/SAMEA7521030/merge/qc/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.stats.visual_report.html",
+                "variant_analysis/pacbio/SAMEA7521030/merge/qc/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.hom_alts.vcf.gz",
+                "variant_analysis/pacbio/SAMEA7521030/merge/qc/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.hom_alts.vcf.gz.csi",
                 "variant_analysis/pacbio/SAMEA7521030/merge/qc/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.stats.visual_report.html",
                 "variant_analysis/pacbio/SAMEA7521030_2",
                 "variant_analysis/pacbio/SAMEA7521030_2/merge",
@@ -104,12 +109,13 @@
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.gz:md5,a7a3df91599b390b501cf2b807f560eb",
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.gz:md5,baefd99c0378d99dd4580e322c23a303",
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.gz:md5,baefd99c0378d99dd4580e322c23a303",
+                "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.hom_alts.vcf.gz:md5,c76a66013ac92839d271439a6aba27c4",
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.gz:md5,3670ede9c3b92fa2a58575ea1129aa62",
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.gz:md5,54531cd87ddea9810409d6c6143786ac",
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.gz:md5,54531cd87ddea9810409d6c6143786ac"
             ]
         ],
-        "timestamp": "2026-06-04T09:47:02.695910333",
+        "timestamp": "2026-06-04T12:10:12.70554132",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.2"

--- a/workflows/variantcalling.nf
+++ b/workflows/variantcalling.nf
@@ -142,6 +142,7 @@ workflow VARIANTCALLING {
     if (params.flag_hom_alts) {
         def sample_vcfs = DEEPVARIANT_CALLER.out.compressed_vcf
             .filter { meta, vcf, _gzi -> meta.sample == params.flag_hom_alts && !vcf.name.contains(".g.vcf") }
+            .ifEmpty { error("--flag_hom_alts '${params.flag_hom_alts}' did not match any sample in the VCF outputs. Check the sample name.") }
         FLAG_HOM_ALTS(
             sample_vcfs,
             [],

--- a/workflows/variantcalling.nf
+++ b/workflows/variantcalling.nf
@@ -15,12 +15,13 @@ include { DEEPVARIANT_CALLER     } from '../subworkflows/local/deepvariant_calle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { paramsSummaryMap       } from 'plugin/nf-schema'
-include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_variantcalling_pipeline'
-include { GUNZIP                 } from '../modules/nf-core/gunzip/main'
-include { SAMTOOLS_FAIDX         } from '../modules/nf-core/samtools/faidx/main'
-include { UNTAR                  } from '../modules/nf-core/untar/main'
+include { paramsSummaryMap               } from 'plugin/nf-schema'
+include { softwareVersionsToYAML         } from '../subworkflows/nf-core/utils_nfcore_pipeline'
+include { methodsDescriptionText         } from '../subworkflows/local/utils_nfcore_variantcalling_pipeline'
+include { GUNZIP                         } from '../modules/nf-core/gunzip/main'
+include { SAMTOOLS_FAIDX                 } from '../modules/nf-core/samtools/faidx/main'
+include { UNTAR                          } from '../modules/nf-core/untar/main'
+include { BCFTOOLS_VIEW as FLAG_HOM_ALTS } from '../modules/nf-core/bcftools/view/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -133,6 +134,21 @@ workflow VARIANTCALLING {
         INPUT_FILTER_SPLIT.out.reads_fasta,
         ch_genome_info.meta.map { meta -> meta.max_length },
     )
+
+
+    //
+    // MODULE: flag homozygous alternative genotypes
+    //
+    if (params.flag_hom_alts) {
+        def sample_vcfs = DEEPVARIANT_CALLER.out.compressed_vcf
+            .filter { meta, vcf, _gzi -> meta.sample == params.flag_hom_alts && !vcf.name.contains(".g.vcf") }
+        FLAG_HOM_ALTS(
+            sample_vcfs,
+            [],
+            [],
+            [],
+        )
+    }
 
 
     //


### PR DESCRIPTION
Closes #40 

I found that the `bcftools view` command has got a filter to extract homozygous alternative genotypes.
I propose making flagging these as a VCF files.

It is enabled whenf a sample name is given in the `--flag_hom_alts` parameter.

<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
