### PR TITLE
Allow `meta.sample` to have repeated values

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -42,4 +42,4 @@ template:
     - igenomes
     - multiqc
     - fastqc
-  version: 2.0.1
+  version: 2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[2.0.2](https://github.com/sanger-tol/variantcalling/releases/tag/2.0.2)] - Qin Shi Huang (patch 2) - [2026-06-05]
+
+### Enhancements & fixes
+
+- Reverted a bug that forced the samplesheet `sample` to have unique entries.
+
 ## [[2.0.1](https://github.com/sanger-tol/variantcalling/releases/tag/2.0.1)] - Qin Shi Huang (patch 1) - [2026-05-15]
 
 ### Enhancements & fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,7 +40,7 @@ authors:
     orcid: https://orcid.org/0000-0001-7029-0785
     website: https://github.com/yz533cb
 cff-version: 1.2.0
-date-released: "2026-05-15"
+date-released: "2026-06-05"
 doi: 10.5281/zenodo.7890527
 license: MIT
 message: If you use this software, please cite it using the metadata from this file

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -46,7 +46,7 @@ license: MIT
 message: If you use this software, please cite it using the metadata from this file
   and all references from CITATIONS.md .
 repository-code: https://github.com/sanger-tol/variantcalling
-title: sanger-tol/variantcalling v2.0.1 - Qin Shi Huang (patch 1) [2026-05-15]
+title: sanger-tol/variantcalling v2.0.2 - Qin Shi Huang (patch 2) [2026-06-05]
 type: software
 url: https://pipelines.tol.sanger.ac.uk/variantcalling
-version: 2.0.1
+version: 2.0.2

--- a/assets/samplesheet_test.csv
+++ b/assets/samplesheet_test.csv
@@ -1,6 +1,6 @@
 sample,datatype,datafile
-SAMEA7521030/ERR10224927_03_cram_1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.cram
-SAMEA7521030/ERR10224927_03_bam_1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bam
-SAMEA7521030_2/ERR10224927_03_cram_2,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.cram
-SAMEA7521030_2/ERR10224927_03_bam_2,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bam
+SAMEA7521030/ERR10224927_03_cram,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.cram
+SAMEA7521030/ERR10224927_03_bam,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bam
+SAMEA7521030_2,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.cram
+SAMEA7521030_2,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bam
 SAMEA7521030_X,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/analysis/icCanRufa1/read_mapping/pacbio/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.bam

--- a/assets/samplesheet_test_align.csv
+++ b/assets/samplesheet_test_align.csv
@@ -1,4 +1,6 @@
 sample,datatype,datafile
 SAMEA7521030/ERR10224927_03,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/genomic_data/icCanRufa1/pacbio/m64094_200730_174533.ccs.bc1010_BAK8A_OA--bc1010_BAK8A_OA_0_03.bam
 SAMEA7521030/ERR10224927_02_1,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/genomic_data/icCanRufa1/pacbio/m64094_200730_174533.ccs.bc1010_BAK8A_OA--bc1010_BAK8A_OA_0_02.bam
+SAMEA7521030_2,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/genomic_data/icCanRufa1/pacbio/m64094_200730_174533.ccs.bc1010_BAK8A_OA--bc1010_BAK8A_OA_0_03.bam
+SAMEA7521030_2,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/genomic_data/icCanRufa1/pacbio/m64094_200730_174533.ccs.bc1010_BAK8A_OA--bc1010_BAK8A_OA_0_02.bam
 SAMEA7521030_X/ERR10224927_02_2,pacbio,https://tolit.cog.sanger.ac.uk/test-data/Cantharis_rufa/genomic_data/icCanRufa1/pacbio/m64094_200730_174533.ccs.bc1010_BAK8A_OA--bc1010_BAK8A_OA_0_02.bam

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -29,6 +29,5 @@
             }
         },
         "required": ["sample", "datatype", "datafile"]
-    },
-    "uniqueEntries": ["sample"]
+    }
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,13 +16,25 @@ You will need to create a samplesheet with information about the samples you wou
 
 ### Multiple runs of the same sample
 
-The `sample` identifiers have to be unique. When a sample (`specimen`) is re-sequenced more than once e.g. to increase sequencing depth, this field is highly recommended to be in form of `specimen/run`, where `specimen` is the same and `run` is unique across these entries. Below is an example for the same sample sequenced across 3 lanes:
+When a specimen is re-sequenced more than once e.g. to increase sequencing depth,
+the `sample` identifier is highly recommended to be in form of `specimen/run`,
+where `specimen` is the same and `run` is unique across these entries.
+Below is an example for the same sample sequenced across 3 lanes:
 
 ```csv title="samplesheet.csv"
 sample,datatype,datafile
 specimen1/run1,pacbio,sample1_1.cram
 specimen1/run2,pacbio,sample1_2.cram
 specimen1/run3,pacbio,sample1_3.cram
+```
+
+However the following simplified samplesheet works too:
+
+```csv title="samplesheet.csv"
+sample,datatype,datafile
+specimen1,pacbio,sample1_1.cram
+specimen1,pacbio,sample1_2.cram
+specimen1,pacbio,sample1_3.cram
 ```
 
 ### Full samplesheet
@@ -36,11 +48,11 @@ specimen2/run2,pacbio,/path/to/data/file/file2.cram
 specimen3/run3,pacbio,/path/to/data/file/file3.bam
 ```
 
-| Column     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sample`   | Custom sample identifier. Must be unique across all entries. Spaces are automatically converted to underscores (`_`), so using underscores in the input is recommended for clarity. For specimens sequenced multiple times, use the format `specimen/run` where `specimen` is the same and `run` is unique for each run (e.g., `SAMEA7521030/ERR10224927`). The forward slash (`/`) is converted to a dot (`.`) in downstream processes. The `sample` field is also used to organize output analysis directories. |
-| `datatype` | Sequencing data type. Must be `pacbio`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `datafile` | The location for either BAM or CRAM file.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Column     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `sample`   | Custom sample identifier. Spaces are automatically converted to underscores (`_`), so using underscores in the input is recommended for clarity. For specimens sequenced multiple times, use the format `specimen/run` where `specimen` is the same and `run` is unique for each run (e.g., `SAMEA7521030/ERR10224927`). The forward slash (`/`) is converted to a dot (`.`) in downstream processes. The `sample` field is also used to organize output analysis directories. |
+| `datatype` | Sequencing data type. Must be `pacbio`.                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `datafile` | The location for either BAM or CRAM file.                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -305,7 +305,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'main'
     nextflowVersion = '!>=25.04.2'
-    version         = '2.0.1'
+    version         = '2.0.2'
     doi             = '10.5281/zenodo.7890527'
 }
 

--- a/ro-crate-metadata.json
+++ b/ro-crate-metadata.json
@@ -159,10 +159,10 @@
             },
             "url": [
                 "https://github.com/sanger-tol/variantcalling",
-                "https://pipelines.tol.sanger.ac.uk/variantcalling/2.0.1/"
+                "https://pipelines.tol.sanger.ac.uk/variantcalling/2.0.2/"
             ],
             "version": [
-                "2.0.1"
+                "2.0.2"
             ]
         },
         {

--- a/subworkflows/local/align_pacbio.nf
+++ b/subworkflows/local/align_pacbio.nf
@@ -48,7 +48,7 @@ workflow ALIGN_PACBIO {
     ch_bams_to_merge = ch_bams.to_merge
         .map { _meta, orig_id_reads ->
             def meta_read = orig_id_reads[0][0]
-            def runs = orig_id_reads.collect { id_read -> id_read[0].run }
+            def runs = orig_id_reads.collect { id_read -> id_read[0].run ?: id_read[0].basename }
             def meta_read_new = meta_read + ['sample': "${meta_read.specimen}/${params.merge_output}", 'id': "${meta_read.fasta_id}.${meta_read.datatype}.${meta_read.specimen}.${params.merge_output}", 'run': "merge", 'merge_source': runs.sort().join("\n")]
             def new_reads = orig_id_reads
                 .sort { a, b -> a[0].id <=> b[0].id} // sort by id to ensure consistent order

--- a/subworkflows/local/input_merge.nf
+++ b/subworkflows/local/input_merge.nf
@@ -30,12 +30,12 @@ workflow INPUT_MERGE {
     ch_reads_to_merge = grouped_reads_meta.to_merge
         .map { _meta, orig_id_reads ->
             def meta_read = orig_id_reads[0][0]
-            def runs = orig_id_reads.collect { id_read -> id_read[0].run }
+            def runs = orig_id_reads.collect { id_read -> id_read[0].run ?: id_read[0].basename }
             def meta_read_new = meta_read + ['sample': "${meta_read.specimen}/${params.merge_output}",
                                             'id': "${meta_read.fasta_id}.${meta_read.datatype}.${meta_read.specimen}.${params.merge_output}",
                                             'run': "merge",
                                             'merge_source': runs.sort().join("\n"),
-                                            'basename': meta_read.basename.replaceAll(meta_read.run, params.merge_output) ]
+                                            'basename': meta_read.run ? meta_read.basename.replaceAll(meta_read.run, params.merge_output) : meta_read.basename ]
             def new_reads = orig_id_reads
                 .sort { a, b -> a[0].id <=> b[0].id} // sort by id to ensure consistent order
                 .collect { id_read -> id_read[1] }

--- a/subworkflows/local/utils_nfcore_variantcalling_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_variantcalling_pipeline/main.nf
@@ -181,7 +181,6 @@ workflow PIPELINE_COMPLETION {
 
 def validateInputSamplesheet(channel) {
     def validFormats = [".cram", ".bam"]
-    def seen_ids = [:]  // Track seen IDs for duplicate detection
 
     return channel.map { row ->
         def (meta, datafile) = row
@@ -214,12 +213,6 @@ def validateInputSamplesheet(channel) {
         meta.id = meta.sample.replace("/",".")
         meta.basename = datafile.baseName
         meta.read_group = "\'@RG\\tID:" + datafile.simpleName + "\\tPL:" + platform + "\\tSM:" + meta.specimen + "\'"
-
-        // INLINE DUPLICATE CHECK - happens immediately
-        if (seen_ids.containsKey(meta.id)) {
-            error("Sample cannot be duplicated (slash (`/`) and dot (`.`) treated as equivalent): ${meta.id}")
-        }
-        seen_ids[meta.id] = true
 
         return [meta, datafile]
     }

--- a/tests/align.nf.test.snap
+++ b/tests/align.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_align": {
         "content": [
-            57,
+            88,
             {
                 "BCFTOOLS_CONCAT_GVCF": {
                     "bcftools": "1.23.1"
@@ -91,6 +91,15 @@
                 "read_mapping/pacbio/SAMEA7521030/merge/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.flagstat",
                 "read_mapping/pacbio/SAMEA7521030/merge/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.idxstats",
                 "read_mapping/pacbio/SAMEA7521030/merge/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.stats",
+                "read_mapping/pacbio/SAMEA7521030_2",
+                "read_mapping/pacbio/SAMEA7521030_2/merge",
+                "read_mapping/pacbio/SAMEA7521030_2/merge/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.cram",
+                "read_mapping/pacbio/SAMEA7521030_2/merge/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.cram.crai",
+                "read_mapping/pacbio/SAMEA7521030_2/merge/SOURCE.txt",
+                "read_mapping/pacbio/SAMEA7521030_2/merge/stats",
+                "read_mapping/pacbio/SAMEA7521030_2/merge/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.flagstat",
+                "read_mapping/pacbio/SAMEA7521030_2/merge/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.idxstats",
+                "read_mapping/pacbio/SAMEA7521030_2/merge/stats/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.stats",
                 "read_mapping/pacbio/SAMEA7521030_X",
                 "read_mapping/pacbio/SAMEA7521030_X/ERR10224927_02_2",
                 "read_mapping/pacbio/SAMEA7521030_X/ERR10224927_02_2/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.cram",
@@ -114,6 +123,19 @@
                 "variant_analysis/pacbio/SAMEA7521030/merge/qc",
                 "variant_analysis/pacbio/SAMEA7521030/merge/qc/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.deepvariant.g.vcf.stats.visual_report.html",
                 "variant_analysis/pacbio/SAMEA7521030/merge/qc/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.deepvariant.vcf.stats.visual_report.html",
+                "variant_analysis/pacbio/SAMEA7521030_2",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.g.vcf.gz",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.g.vcf.gz.csi",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.g.vcf.gz.gzi",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.g.vcf.gz.tbi",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.vcf.gz",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.vcf.gz.csi",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.vcf.gz.gzi",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.vcf.gz.tbi",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/qc",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/qc/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.g.vcf.stats.visual_report.html",
+                "variant_analysis/pacbio/SAMEA7521030_2/merge/qc/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.vcf.stats.visual_report.html",
                 "variant_analysis/pacbio/SAMEA7521030_X",
                 "variant_analysis/pacbio/SAMEA7521030_X/ERR10224927_02_2",
                 "variant_analysis/pacbio/SAMEA7521030_X/ERR10224927_02_2/GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.g.vcf.gz",
@@ -133,29 +155,38 @@
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.flagstat:md5,46d82921bb895f051b6a82658c18286f",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.idxstats:md5,7be1ca471671613630279bd5179b558f",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.stats:md5,b9d9900d8a235507d1da355251dd804f",
+                "SOURCE.txt:md5,25c03a093530e61e05211bcf0dda42d6",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.flagstat:md5,46d82921bb895f051b6a82658c18286f",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.idxstats:md5,7be1ca471671613630279bd5179b558f",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.stats:md5,76d5f6a66a101593be42911b7ec90a74",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.flagstat:md5,2c5d67733407c8eddc2a7d59e035606e",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.idxstats:md5,122ade711785188461e196872324044b",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.stats:md5,6d8225a348d6f2c8f2f45f00f496358f",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.deepvariant.g.vcf.stats.visual_report.html:md5,1cd5b8568a0e516923c093391768a100",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.deepvariant.vcf.stats.visual_report.html:md5,f3f2f8662fb11df5bfdddf94e230eb86",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.g.vcf.stats.visual_report.html:md5,4cc1a63e65f416367ac82c90dea380e0",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.vcf.stats.visual_report.html:md5,f09145d0ea76c5de09f0a7011a819d69",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.g.vcf.stats.visual_report.html:md5,d58e91136f961c0a81624f2ca79518e7",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.vcf.stats.visual_report.html:md5,e76ad1cfd5cd12a4e5f17c7984f06bfd"
             ],
             [
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.deepvariant.g.vcf.gz:md5,6faaf6ecf0b7c5cc664d2da6f9a1069b",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.deepvariant.vcf.gz:md5,f3230403ec480904033694159f064800",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.g.vcf.gz:md5,6faaf6ecf0b7c5cc664d2da6f9a1069b",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.deepvariant.vcf.gz:md5,f3230403ec480904033694159f064800",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.g.vcf.gz:md5,a82bcaa26c16328cf19b72beee49b80d",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.deepvariant.vcf.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030.merge.minimap2.cram:md5,8687ba1f97f527df6dda7b5ad73b245e",
+                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_2.merge.minimap2.cram:md5,8687ba1f97f527df6dda7b5ad73b245e",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.cram:md5,49774288f3270c0d31fc7139a1f33a49"
             ]
         ],
-        "timestamp": "2026-05-07T12:31:07.898398",
+        "timestamp": "2026-06-04T22:21:10.619994488",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.2"
+            "nextflow": "25.10.4"
         }
     }
 }

--- a/tests/align.nf.test.snap
+++ b/tests/align.nf.test.snap
@@ -74,7 +74,7 @@
                     "deepvariant": "1.10.0"
                 },
                 "Workflow": {
-                    "sanger-tol/variantcalling": "v2.0.1"
+                    "sanger-tol/variantcalling": "v2.0.2"
                 }
             },
             [

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -91,10 +91,10 @@
                 "variant_analysis/pacbio/SAMEA7521030_X/qc/GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.stats.visual_report.html"
             ],
             [
-                "SOURCE.txt:md5,e30fa0754f9d79d9279413bdbb5fec9c",
+                "SOURCE.txt:md5,8fcc07c661aa1eb8b6641b36be681b04",
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.stats.visual_report.html:md5,2a5c7e1a9ba325d175cf9ad1e410c6c7",
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.stats.visual_report.html:md5,68eb791e98d22eee398aeb35eef2be33",
-                "SOURCE.txt:md5,6749ca92d21ea1ce5fe427932de02583",
+                "SOURCE.txt:md5,aae797485df164890d2155ea31a2839b",
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.stats.visual_report.html:md5,2a5c7e1a9ba325d175cf9ad1e410c6c7",
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.stats.visual_report.html:md5,68eb791e98d22eee398aeb35eef2be33",
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.g.vcf.stats.visual_report.html:md5,4258fda623c3a1c5e50338a4819763a6",
@@ -109,10 +109,10 @@
                 "GCA_947369205.1.unmasked.pacbio.icCanRufa1_0_3.deepvariant.vcf.gz:md5,54531cd87ddea9810409d6c6143786ac"
             ]
         ],
-        "timestamp": "2026-05-07T12:27:31.990126",
+        "timestamp": "2026-06-04T22:24:27.947044082",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.2"
+            "nextflow": "25.10.4"
         }
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -41,7 +41,7 @@
                     "deepvariant": "1.10.0"
                 },
                 "Workflow": {
-                    "sanger-tol/variantcalling": "v2.0.1"
+                    "sanger-tol/variantcalling": "v2.0.2"
                 }
             },
             [


### PR DESCRIPTION
I know we had agreed in our discussion and in the code review on requiring `meta.sample` to be unique, but as I was running the pipeline on Psyche data and got a lot of failures, I realised it's because I hadn't made `meta.sample` unique when there was multiple BAMs for the same tolid.

Before updating the samplesheets, I thought: is the unicity really necessary ?

As far as I could see, the code doesn't require it to be unique. It's not used as a key for like `join`.
The main thing I had to add is a fallback for `meta.run` being empty.

What do you think ? Did I miss anything ?

<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
