### PR TITLE
Stable ordering of BAM files before merging

### DIFF
--- a/subworkflows/local/align_pacbio.nf
+++ b/subworkflows/local/align_pacbio.nf
@@ -35,7 +35,7 @@ workflow ALIGN_PACBIO {
 
     // Collect all alignment output by sample name
     ch_bams = MINIMAP2_ALIGN.out.bam
-        .map { meta, bam -> [['id': meta.specimen, 'datatype': meta.datatype], [['id':meta.id, 'specimen': meta.specimen, 'datatype': meta.datatype, 'sample': meta.sample, 'run': meta.run, 'fasta_id': meta.fasta_id], bam]] }
+        .map { meta, bam -> [['id': meta.specimen, 'datatype': meta.datatype], [meta, bam]] }
         .groupTuple(by: [0])
         .branch { _meta, bams ->
             to_merge: bams.size() > 1

--- a/tests/align.nf.test.snap
+++ b/tests/align.nf.test.snap
@@ -163,7 +163,7 @@
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.flagstat:md5,46d82921bb895f051b6a82658c18286f",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.idxstats:md5,7be1ca471671613630279bd5179b558f",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030.merge.minimap2.stats.gz:md5,33c9284481eaadf7813857ac32fce4ad",
-                "SOURCE.txt:md5,25c03a093530e61e05211bcf0dda42d6",
+                "SOURCE.txt:md5,3228bb67e7a7edaccb26d0dc7e48c7ca",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_2.merge.minimap2.flagstat:md5,46d82921bb895f051b6a82658c18286f",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_2.merge.minimap2.idxstats:md5,7be1ca471671613630279bd5179b558f",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_2.merge.minimap2.stats.gz:md5,ef4cef251af26e75a9b2a51f02c91a4f",
@@ -192,10 +192,10 @@
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.gzipped.pacbio.SAMEA7521030_X.ERR10224927_02_2.minimap2.cram:md5,49774288f3270c0d31fc7139a1f33a49"
             ]
         ],
-        "timestamp": "2026-06-13T11:34:47.587227567",
+        "timestamp": "2026-09-09T10:31:21.967141102",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }


### PR DESCRIPTION
As in the other pipelines, I've been trying to make the outputs identical across reruns so that we can rely on CI and nf-test snapshots.
Here the problem was that the sort key for the BAM files being merged was using meta keys that were not present.
The code was essentially making a sub-set of the input meta map, but without `basename`. If added, the sub-set would be the entire original meta except `read_group` which is harmless at this stage. So rather than keep on building a sub-set, I just pass the original `meta`
<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
