### PR TITLE
Repeatability again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support gzipped FASTA
 - Added a `--flag_hom_alts` option to flag homozygous alternative genotypes
 - In alignment mode, the SAMTOOLS_STATS output is now compressed in gzip format
-- Upgraded to the nf-core template v4.1.0
+- Upgraded to the nf-core template v4.1.0 and bumped up the nf-schema plugin to ensure
+  seamless compatibility with Nextflow 26.04
 - Slack / Teams functionality now moved to Nextflow plugins ([nf-slack](https://github.com/seqeralabs/nf-slack), [nf-teams](https://github.com/nvnieuwk/nf-teams))
 - Write CRAM version 3.0 after `samtools filter` to be compatible with Deepvariant
 - Regenerated the pipeline diagram with nf-metro

--- a/nextflow.config
+++ b/nextflow.config
@@ -315,7 +315,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.5.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.7.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {

--- a/subworkflows/local/align_pacbio.nf
+++ b/subworkflows/local/align_pacbio.nf
@@ -7,7 +7,6 @@ include { MINIMAP2_ALIGN } from '../../modules/nf-core/minimap2/align/main'
 include { SAMTOOLS_MERGE } from '../../modules/nf-core/samtools/merge/main'
 include { CONVERT_STATS  } from '../../subworkflows/local/convert_stats'
 
-
 workflow ALIGN_PACBIO {
     take:
     fasta // channel: [ val(meta), /path/to/fasta[.gz], /path/to/fai ]
@@ -49,7 +48,15 @@ workflow ALIGN_PACBIO {
         .map { _meta, orig_id_reads ->
             def meta_read = orig_id_reads[0][0]
             def runs = orig_id_reads.collect { id_read -> id_read[0].run ?: id_read[0].basename }
-            def meta_read_new = meta_read + ['sample': "${meta_read.specimen}/${params.merge_output}", 'id': "${meta_read.fasta_id}.${meta_read.datatype}.${meta_read.specimen}.${params.merge_output}", 'run': "merge", 'merge_source': runs.sort().join("\n")]
+            def meta_read_new = [
+                'datatype': meta_read.datatype,
+                'fasta_id': meta_read.fasta_id,
+                'sample': "${meta_read.specimen}/${params.merge_output}",
+                'id': "${meta_read.fasta_id}.${meta_read.datatype}.${meta_read.specimen}.${params.merge_output}",
+                'run': "merge",
+                'merge_source': runs.sort().join("\n"),
+                // no need to set 'basename' now as it'll be set after merging
+            ]
             def new_reads = orig_id_reads
                 .sort { a, b -> a[0].id <=> b[0].id} // sort by id to ensure consistent order
                 .collect { id_read -> id_read[1] }

--- a/subworkflows/local/align_pacbio.nf
+++ b/subworkflows/local/align_pacbio.nf
@@ -58,7 +58,8 @@ workflow ALIGN_PACBIO {
                 // no need to set 'basename' now as it'll be set after merging
             ]
             def new_reads = orig_id_reads
-                .sort { a, b -> a[0].id <=> b[0].id} // sort by id to ensure consistent order
+                // sort by id, and then by basename, to ensure consistent order
+                .sort { id_read -> [id_read[0].id, id_read[0].basename] }
                 .collect { id_read -> id_read[1] }
             [meta_read_new, new_reads, []]
         }

--- a/subworkflows/local/input_merge.nf
+++ b/subworkflows/local/input_merge.nf
@@ -31,11 +31,15 @@ workflow INPUT_MERGE {
         .map { _meta, orig_id_reads ->
             def meta_read = orig_id_reads[0][0]
             def runs = orig_id_reads.collect { id_read -> id_read[0].run ?: id_read[0].basename }
-            def meta_read_new = meta_read + ['sample': "${meta_read.specimen}/${params.merge_output}",
-                                            'id': "${meta_read.fasta_id}.${meta_read.datatype}.${meta_read.specimen}.${params.merge_output}",
-                                            'run': "merge",
-                                            'merge_source': runs.sort().join("\n"),
-                                            'basename': meta_read.run ? meta_read.basename.replaceAll(meta_read.run, params.merge_output) : meta_read.basename ]
+            def meta_read_new = [
+                'datatype': meta_read.datatype,
+                'fasta_id': meta_read.fasta_id,
+                'sample': "${meta_read.specimen}/${params.merge_output}",
+                'id': "${meta_read.fasta_id}.${meta_read.datatype}.${meta_read.specimen}.${params.merge_output}",
+                'run': "merge",
+                'merge_source': runs.sort().join("\n"),
+                'basename': meta_read.run ? meta_read.basename.replaceAll(meta_read.run, params.merge_output) : meta_read.basename,
+            ]
             def new_reads = orig_id_reads
                 .sort { a, b -> a[0].id <=> b[0].id} // sort by id to ensure consistent order
                 .collect { id_read -> id_read[1] }

--- a/subworkflows/local/input_merge.nf
+++ b/subworkflows/local/input_merge.nf
@@ -41,7 +41,8 @@ workflow INPUT_MERGE {
                 'basename': meta_read.run ? meta_read.basename.replaceAll(meta_read.run, params.merge_output) : meta_read.basename,
             ]
             def new_reads = orig_id_reads
-                .sort { a, b -> a[0].id <=> b[0].id} // sort by id to ensure consistent order
+                // sort by id, and then by basename, to ensure consistent order
+                .sort { id_read -> [id_read[0].id, id_read[0].basename] }
                 .collect { id_read -> id_read[1] }
             [meta_read_new, new_reads, []]
         }

--- a/subworkflows/local/utils_nfcore_variantcalling_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_variantcalling_pipeline/main.nf
@@ -87,7 +87,7 @@ workflow PIPELINE_INITIALISATION {
         before_text,
         after_text,
         command,
-        false
+        null
     )
 
     //


### PR DESCRIPTION
Follow-up of #172 

I got confused and misread the code. Turns out `basename` was _not_ used as a sort key ... This is what I fix in this PR (the `.sort` calls).
I also rewrote the definition of `meta_read_new` so that we only select the `meta_read` keys that are useful and not overridden by the new meta map straight ahead. I also reformatted the code so that it is easier to read. The two files can now be opened side by side to show this section is _identical_ between both.

I also update nf-schema in preparation for the release.

<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
