### PR TITLE
Fixed the stub run

### DIFF
--- a/workflows/variantcalling.nf
+++ b/workflows/variantcalling.nf
@@ -132,7 +132,7 @@ workflow VARIANTCALLING {
     //
     DEEPVARIANT_CALLER(
         INPUT_FILTER_SPLIT.out.reads_fasta,
-        ch_genome_info.meta.map { meta -> meta.max_length },
+        ch_genome_info.meta.map { meta -> meta.max_length ?: 0},
     )
 
 


### PR DESCRIPTION
The stub run doesn't run to completion because in stub mode all files are empty so `meta.max_length` is _null_, which `map` filters out, making the channel empty. So here I just change it to 0 to ensure the channel is not empty,

<!--
# sanger-tol/variantcalling pull request

Many thanks for contributing to sanger-tol/variantcalling!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/variantcalling/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
